### PR TITLE
"Save Template" button forgotten

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -698,7 +698,7 @@
       'class': 'cb-wrap'
     }).append(cbHeader, cbUL);
 
-    $stageWrap.append($sortableFields, cbWrap, viewXML, actionLinks);
+    $stageWrap.append($sortableFields, cbWrap, viewXML, actionLinks, saveAll);
     $stageWrap.before($formWrap);
     $formWrap.append($stageWrap, cbWrap);
 


### PR DESCRIPTION
I added the last parameter to this line, so the "Save Template" button, appear.

$stageWrap.append($sortableFields, cbWrap, viewXML, actionLinks, saveAll);