### PR TITLE
Use $ as jQuery.noConflict

### DIFF
--- a/dist/form-builder.js
+++ b/dist/form-builder.js
@@ -194,7 +194,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
 function formBuilderHelpersFn(opts, formBuilder) {
   'use strict';
-
+  var $ = jQuery.noConflict();
   var _helpers = {
     doCancel: false
   };


### PR DESCRIPTION
Thanks for awesome FormBuilder
jQuery will conflict "Uncaught TypeError: $ is not a function" when use it in Joomla!.

My simple idea just define a local $ = jQuery.noConflict();