### PR TITLE
Disable scroll on ControlBox fields

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -394,6 +394,7 @@
       opacity: 0.9,
       connectWith: $sortableFields,
       cursor: 'move',
+      scroll: false,
       placeholder: 'ui-state-highlight',
       start: _helpers.startMoving,
       stop: _helpers.stopMoving,


### PR DESCRIPTION
When creating really long forms (20-30 fields) the drag event from the ControlBox auto scrolls to the bottom. This makes it impossible to drop fields into the middle of a form.  Simple fix, minimal impact.