### PR TITLE
Added typeUserEvents option

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -6,6 +6,7 @@
 
     var defaults = {
       typeUserAttrs: {}, //+gimigliano
+      typeUserEvents: {}, //+gimigliano
       controlPosition: 'right',
       controlOrder: [
         'autocomplete',
@@ -1072,7 +1073,10 @@
         _helpers.closeAllEdit($sortableFields);
         _helpers.toggleEdit(lastID);
       }
-
+      
+      //+gimigliano
+      if (opts.typeUserEvents[type] && opts.typeUserEvents[type]['onadd']) opts.typeUserEvents[type]['onadd']($('#'+lastID));
+     
       lastID = _helpers.incrementId(lastID);
     };
 
@@ -1161,6 +1165,9 @@
       $clone.attr('name', cloneName);
       $clone.addClass('cloned');
       $('.sortable-options', $clone).sortable();
+    //+gimigliano
+      if (opts.typeUserEvents[type] && opts.typeUserEvents[type]['onclone']) opts.typeUserEvents[type]['onclone']($('#'+lastID));
+      
       lastID = _helpers.incrementId(lastID);
       return $clone;
     };


### PR DESCRIPTION
Suppose you want add an attribute "pattern" in text fields and you want to hide (and disable) it when the "email" subtype is selected, you'll need to attache onchane evento when the text field is added.

     

```
typeUserAttrs:{
                       'text':{
                                'pattern':{'label':'Pattern',
                               }
                       } , 
 typeUserEvents:{
                       'text':{
                               'onadd':function(fld){ fld.find('.fld-subtype:first')
                                                                    .change(function(h){
                                                                                     if($(this).val()=='Password') 
                                                                                            { fld.find('.pattern-wrap:eq(0)').hide();
                                                                                              fld.find('.fld-pattern:eq(0)').prop('disabled',true);
                                                                                            }
                                                                                    else {fld.find('.pattern-wrap:eq(0)').show();
                                                                                            fld.find('.fld-pattern:eq(0)').prop('disabled',false);
                                                                                           }     
                                                                         } );  
                                                               }
                                  }   
                        },
```
    