### PR TITLE
Hotfix: addField index 0 without fields

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -386,7 +386,6 @@
       beforeStop: _helpers.beforeStop,
       distance: 3,
       update: function(event, ui) {
-        event = event;
         if (_helpers.doCancel) {
           return false;
         }
@@ -1415,7 +1414,7 @@
       showData: _helpers.showData,
       save: _helpers.save,
       addField: (field, index) => {
-        _helpers.stopIndex = index;
+        _helpers.stopIndex = $sortableFields[0].children.length ? index : undefined;
         prepFieldVars(field);
         document.dispatchEvent(formBuilder.events.fieldAdded);
       },

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1,6 +1,5 @@
 function formBuilderHelpersFn(opts, formBuilder) {
   'use strict';
-  console.log(formBuilder);
   var _helpers = {
     doCancel: false
   };
@@ -41,7 +40,6 @@ function formBuilderHelpersFn(opts, formBuilder) {
    * @param  {Object} ui
    */
   _helpers.startMoving = function(event, ui) {
-    event = event;
     ui.item.show().addClass('moving');
     _helpers.startIndex = $('li', this).index(ui.item);
   };
@@ -53,7 +51,6 @@ function formBuilderHelpersFn(opts, formBuilder) {
    * @param  {Object} ui
    */
   _helpers.stopMoving = function(event, ui) {
-    event = event;
     ui.item.removeClass('moving');
     if (_helpers.doCancel) {
       $(ui.sender).sortable('cancel');
@@ -68,8 +65,6 @@ function formBuilderHelpersFn(opts, formBuilder) {
    * Logic for canceling the sort or drop.
    */
   _helpers.beforeStop = function(event, ui) {
-    event = event;
-
     var form = document.getElementById(opts.formID),
       lastIndex = form.children.length - 1,
       cancelArray = [];


### PR DESCRIPTION
Adding a field to 0 index when no fields are on the stage does not work. Set index to undefined if there are no fields on the stage.

Removed debug console.log