### PR TITLE
Fix alignment when in a bootstrap form-horizontal element

### DIFF
--- a/src/sass/base/_bs.scss
+++ b/src/sass/base/_bs.scss
@@ -275,6 +275,7 @@ textarea.form-control {
 }
 
 .form-group {
+  margin-left: 0px;
   margin-bottom: 15px;
 }
 


### PR DESCRIPTION
When I put the editor into a bootstrap form, the alignment of the elements are out, due to the 15px margin on the form-group in bootstrap. This fix overrides the left margin and forces it to 0px.