### PR TITLE
Repair bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "!dist/**/*"
   ],
   "dependencies": {
-    "jQuery UI Sortable": "jquery-ui-sortable#*",
+    "jquery-ui-sortable": "*",
     "jquery": "^3.1.1"
   },
   "repository": {


### PR DESCRIPTION
As it stands, the bower.json file points to the incorrect bower repo. I've repaired the reference to the bower repo so that installations with bower will not cause an error.

[Bower URL](https://libraries.io/bower/jquery-ui-sortable)