### PR TITLE
Fixed few linting errors

### DIFF
--- a/src/js/kc-toggle.js
+++ b/src/js/kc-toggle.js
@@ -18,7 +18,7 @@
 
     var kctOn = `<div class="kct-on">${opts.messages.on}</div>`,
         kctOff = `<div class="kct-off">${opts.messages.off}</div>`,
-        kctHandle = `<div class="kct-handle"></div>`,
+        kctHandle = '<div class="kct-handle"></div>',
         kctInner = `<div class="kct-inner">${kctOn}${kctHandle}${kctOff}</div>`;
 
     $kcToggle.append(kctInner);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -239,7 +239,7 @@ fbUtils.parseXML = function(xmlString) {
     for (var i = 0; i < fields.length; i++) {
       let fieldData = fbUtils.parseAttrs(fields[i]);
 
-      if (fields[i].children.length) {
+      if (fields[i].children && fields[i].children.length) {
         fieldData.values = fbUtils.parseOptions(fields[i]);
       }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -348,11 +348,12 @@ fbUtils.fieldRender = function(fieldData, opts, preview = false) {
 
     switch (fieldData.type) {
       case 'textarea':
-      case 'rich-text':
+      case 'rich-text': {
         delete fieldData.type;
         let fieldVal = fieldData.value || '';
         fieldMarkup = `${fieldLabel}<textarea ${fieldDataString}>${fieldVal}</textarea>`;
         break;
+      }
       case 'select':
         var optionAttrsString;
         fieldData.type = fieldData.type.replace('-group', '');
@@ -378,7 +379,7 @@ fbUtils.fieldRender = function(fieldData, opts, preview = false) {
         fieldMarkup = `${fieldLabel}<select ${fieldDataString}>${optionsMarkup}</select>`;
         break;
       case 'checkbox-group':
-      case 'radio-group':
+      case 'radio-group': {
         let optionAttrs;
         fieldData.type = fieldData.type.replace('-group', '');
 
@@ -417,6 +418,7 @@ fbUtils.fieldRender = function(fieldData, opts, preview = false) {
         }
         fieldMarkup = `${fieldLabel}<div class="${fieldData.type}-group">${optionsMarkup}</div>`;
         break;
+      }
       case 'text':
       case 'password':
       case 'email':


### PR DESCRIPTION
fbUtils.fieldRender `src/js/utils.js`
- Unexpected lexical declaration in case block  `no-case-declarations`
(lines 351, 381)

var kctHandle `js/kc-toggle.js`
- Strings must use singlequote `quotes` (line 21)

From `✖ 10 problems (10 errors, 0 warnings)` to `✖ 7 problems (7
errors, 0 warnings)`