### PR TITLE
inputSets name attribute problem

### DIFF
--- a/dist/form-builder.js
+++ b/dist/form-builder.js
@@ -1961,8 +1961,8 @@ function formBuilderEventsFn() {
       } else {
         field = Object.assign({}, $field);
       }
-
-      field.name = isNew ? nameAttr(field) : field.name || nameAttr(field);
+      
+      field.name = isNew ? field.name || nameAttr(field) : nameAttr(field);
 
       if (isNew && utils.inArray(field.type, ['text', 'number', 'file', 'select', 'textarea'])) {
         field.className = 'form-control'; // backwards compatibility

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -532,7 +532,7 @@
         field = Object.assign({}, $field);
       }
 
-      field.name = isNew ? nameAttr(field) : ( field.name || nameAttr(field) );
+      field.name = isNew ? ( field.name || nameAttr(field) ) : nameAttr(field);
 
       if (isNew && utils.inArray(field.type, ['text', 'number', 'file', 'select', 'textarea'])) {
         field.className = 'form-control'; // backwards compatibility


### PR DESCRIPTION
On line 1965  it was't taking the name attribute from inputSets . It was using nameAttr(field) in all cases.