### PR TITLE
ability for getStyles to handle receiving a single css file

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -732,6 +732,9 @@ import {defaultSubtypes, filter} from './dom';
     if (utils.isCached(scriptScr, 'css')) {
       return;
     }
+    if (!Array.isArray(scriptScr)) {
+      scriptScr = [scriptScr];
+    }
     const appendStyle = (href) => {
       const link = document.createElement('link');
       link.type = 'text/css';


### PR DESCRIPTION
This got removed somewhere along the line & it breaks controls that only register a single css file.