### PR TITLE
This is a cool new feature of formRender that allows you to render just a single field

### DIFF
--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -208,7 +208,7 @@ class FormRender {
    * @param {Object} element - an optional DOM element to render the field into - if not specified will just return the rendered field - note if you do this you will need to manually call element.dispatchEvent('fieldRendered') on the returned element when it is rendered into the DOM
    * @return {Object} the formRender object
    */
-  renderSingle(element = null) {
+  renderControl(element = null) {
     let opts = this.options;
     let fieldData = opts.formData;
     if (!fieldData || Array.isArray(fieldData)) {
@@ -219,7 +219,8 @@ class FormRender {
     // determine the control class for this type, and then build it
     let engine = new opts.layout();
     let controlClass = control.getClass(fieldData.type, fieldData.subtype);
-    let field = engine.build(controlClass, sanitizedField, true);
+    let forceTemplate = opts.forceTemplate || 'hidden'; // support the ability to override what layout template the control is rendered using. This can be used to output the whole row (including label, help etc) using the standard templates if desired.
+    let field = engine.build(controlClass, sanitizedField, forceTemplate);
     element.appendFormFields(field);
     opts.notify.success(opts.messages.formRendered);
     return this;
@@ -242,14 +243,14 @@ class FormRender {
    * @param {Object} options - optional subset of formRender options - doesn't support container or other form rendering based options.
    * @return {DOMElement} the rendered field
    */
-  $.fn.fieldRender = function(data, options = {}) {
+  $.fn.controlRender = function(data, options = {}) {
     options.formData = data;
     options.dataType = typeof data === 'string' ? 'json' : 'xml';
     let formRender = new FormRender(options);
     let elems = this;
     elems.each(function(i) {
       elems[i].dataset.formRender = formRender;
-      return formRender.renderSingle(elems[i]);
+      return formRender.renderControl(elems[i]);
     });
     return elems;
   };

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -10,7 +10,6 @@ import controlCustom from './control/custom';
 
 /**
  * FormRender Class
- * @todo: prototype.js compatibility
  */
 class FormRender {
 
@@ -86,7 +85,7 @@ class FormRender {
      * @param  {Object} fields Node elements
      */
     if (typeof Element.prototype.appendFormFields !== 'function') {
-      Element.prototype.appendFormFields = function (fields) {
+      Element.prototype.appendFormFields = function(fields) {
         let element = this;
         if (!Array.isArray(fields)) {
           fields = [fields];
@@ -102,7 +101,7 @@ class FormRender {
      * Extend Element prototype to remove content
      */
     if (typeof Element.prototype.emptyContainer !== 'function') {
-      Element.prototype.emptyContainer = function () {
+      Element.prototype.emptyContainer = function() {
         let element = this;
         while (element.lastChild) {
           element.removeChild(element.lastChild);
@@ -113,8 +112,8 @@ class FormRender {
 
   /**
    * Clean up passed object configuration to prepare for use with the markup function
-   * @param field - object of field configuration
-   * @returns sanitized field object
+   * @param {Object} field - object of field configuration
+   * @return {Object} sanitized field object
    */
   santizeField(field) {
     let sanitizedField = Object.assign({}, field);
@@ -203,8 +202,8 @@ class FormRender {
   /**
    * Render a single control / field
    * Expects only a single field configuration to be set in opt.formData
-   * @param element {jQuery Element} an optional element to render the field into - if not specified will just return the rendered field - note if you do this you will need to manually call element.dispatchEvent('fieldRendered') on the returned element when it is rendered into the DOM
-   * @returns {DOMElement} the rendered field
+   * @param {Object} element - an optional DOM element to render the field into - if not specified will just return the rendered field - note if you do this you will need to manually call element.dispatchEvent('fieldRendered') on the returned element when it is rendered into the DOM
+   * @return {Object} the formRender object
    */
   renderSingle(element = null) {
     let opts = this.options;
@@ -220,6 +219,7 @@ class FormRender {
     let field = engine.build(controlClass, sanitizedField, true);
     element.appendFormFields(field);
     opts.notify.success(opts.messages.formRendered);
+    return this;
   }
 }
 
@@ -235,9 +235,9 @@ class FormRender {
 
   /**
    * renders an individual field into the current element
-   * @param data - data structure for a single field output from formBuilder
-   * @param options - optional subset of formRender options - doesn't support container or other form rendering based options.
-   * @returns {DOMElement} the rendered field
+   * @param {Object} data - data structure for a single field output from formBuilder
+   * @param {Object} options - optional subset of formRender options - doesn't support container or other form rendering based options.
+   * @return {DOMElement} the rendered field
    */
   $.fn.fieldRender = function(data, options = {}) {
     options.formData = data;

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -65,7 +65,10 @@ class FormRender {
         json: formData => window.JSON.parse(formData)
       };
 
-      this.options.formData = setData[this.options.dataType](this.options.formData) || false;
+      // if the user hasn't passed a pre-parsed formData object, parse it according to the specified dataType
+      if (typeof this.options.formData !== 'object') {
+        this.options.formData = setData[this.options.dataType](this.options.formData) || false;
+      }
     })();
 
     // ability for controls to have their own configuration / options of the format control identifier (type, or type.subtype): {options}

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -69,9 +69,10 @@ export default class layout {
    *   - hidden - this control shouldn't render anything visible to the page
    * @param {Object} renderControl - the relevant control class
    * @param {Object} data - configuration data passed through formData for this control
+   * @param {String} forceTemplate - programatically force the template with which this control to be rendered
    * @return {Object} element
    */
-  build(renderControl, data) {
+  build(renderControl, data, forceTemplate) {
     // prepare the data
     if (this.preview) {
       if (data.name) {
@@ -95,7 +96,12 @@ export default class layout {
     let help = this.help();
 
     // process the relevant layout template
-    let elementTemplate = this.isTemplate(field.layout) ? field.layout : 'default';
+    let elementTemplate;
+    if (forceTemplate && this.isTemplate(forceTemplate)) {
+        elementTemplate = forceTemplate;
+    } else {
+		elementTemplate = this.isTemplate(field.layout) ? field.layout : 'default';
+    }
     let element = this.processTemplate(elementTemplate, field.field, label, help);
 
     // execute prerender events


### PR DESCRIPTION
Declares a $.fn.fieldRender method, allowing you to easily render a single formBuilder field at a time.
Also if you have access to the object you can call FormRender.renderSingle(...).

Also cleaned up the jsdoc to make webpack happy & stop throwing errors.

Seems to all run nice.