### PR TITLE
New control plugin to replace the default file upload type

### DIFF
--- a/src/js/control_plugins/fineuploader.js
+++ b/src/js/control_plugins/fineuploader.js
@@ -49,6 +49,7 @@ E.g. var opts = {
 For assistance with setting up Fine Uploader in your application, please refer to:
   * https://docs.fineuploader.com/quickstart/01-getting-started.html
   * You can download from here: https://fineuploader.com/customize
+  * Your 'js' option should point to the jquery.fine-uploader.min.js file (note this is the jQuery plugin version)
   * This plugin is by default configured to use the 'Traditional' build, but you can easily reconfigure by passing appropriate Fine Uploader configuration options to controlConfig.file.
   * A simple php upload handler endpoint can be found here: https://github.com/FineUploader/php-traditional-server. To use this for your handler, simply set the controlConfig.fineuploader.handler option to be '/path/to/php-traditional-server/endpoint.php'
 `;

--- a/src/js/control_plugins/fineuploader.js
+++ b/src/js/control_plugins/fineuploader.js
@@ -1,0 +1,191 @@
+/**
+ * Fineuploader class - render the fineuploader tool (https://fineuploader.com) in place of the traditional file upload widget
+ */
+
+// configure the class for runtime loading
+if (!window.fbControls) window.fbControls = [];
+window.fbControls.push(function(controlClass) {
+  /**
+   * Fine uploader class
+   */
+  class controlFineUpload extends controlClass {
+
+    /**
+     * Class configuration - return the icons & label related to this control
+     * @return definition object
+     */
+    static get definition() {
+      return {
+        i18n: {
+          default: 'File Upload'
+        }
+      };
+    }
+
+    /**
+     * javascript & css to load
+     */
+    configure() {
+      this.js = this.classConfig.js;
+      this.css = this.classConfig.css;
+      if (!this.js || !this.css) {
+        let message = `Error intializing the Fine Uploader control. It does not appear to have been configured.
+To do this correctly, please specify formbuilder/formrender options under controlConfig.file.
+  
+E.g. var opts = {
+  // other formbuilder options here
+  
+  controlConfig: {
+    file: {
+      js: '/path/to.js',
+      css: '/path/to.css',
+      handler: '/path/to/handler.php',
+      
+      // other fine uploader configuration options here  
+    }
+  }
+};
+
+For assistance with setting up Fine Uploader in your application, please refer to:
+  * https://docs.fineuploader.com/quickstart/01-getting-started.html
+  * You can download from here: https://fineuploader.com/customize
+  * This plugin is by default configured to use the 'Traditional' build, but you can easily reconfigure by passing appropriate Fine Uploader configuration options to controlConfig.file.
+  * A simple php upload handler endpoint can be found here: https://github.com/FineUploader/php-traditional-server. To use this for your handler, simply set the controlConfig.fineuploader.handler option to be '/path/to/php-traditional-server/endpoint.php'
+`;
+        throw new Error(message);
+      }
+
+      // fineuploader template that needs to be defined for the UI
+      let template = `
+        <div class="qq-uploader-selector qq-uploader qq-gallery" qq-drop-area-text="Drop files here">
+          <div class="qq-total-progress-bar-container-selector qq-total-progress-bar-container">
+            <div role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" class="qq-total-progress-bar-selector qq-progress-bar qq-total-progress-bar"></div>
+          </div>
+          <div class="qq-upload-drop-area-selector qq-upload-drop-area" qq-hide-dropzone>
+            <span class="qq-upload-drop-area-text-selector"></span>
+          </div>
+          <div class="qq-upload-button-selector qq-upload-button">
+            <div>Upload a file</div>
+          </div>
+          <span class="qq-drop-processing-selector qq-drop-processing">
+                    <span>Processing dropped files...</span>
+                    <span class="qq-drop-processing-spinner-selector qq-drop-processing-spinner"></span>
+                </span>
+          <ul class="qq-upload-list-selector qq-upload-list" role="region" aria-live="polite" aria-relevant="additions removals">
+            <li>
+              <span role="status" class="qq-upload-status-text-selector qq-upload-status-text"></span>
+              <div class="qq-progress-bar-container-selector qq-progress-bar-container">
+                <div role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" class="qq-progress-bar-selector qq-progress-bar"></div>
+              </div>
+              <span class="qq-upload-spinner-selector qq-upload-spinner"></span>
+              <div class="qq-thumbnail-wrapper">
+                <img class="qq-thumbnail-selector" qq-max-size="120" qq-server-scale>
+              </div>
+              <button type="button" class="qq-upload-cancel-selector qq-upload-cancel">X</button>
+              <button type="button" class="qq-upload-retry-selector qq-upload-retry">
+                <span class="qq-btn qq-retry-icon" aria-label="Retry"></span>
+                Retry
+              </button>
+    
+              <div class="qq-file-info">
+                <div class="qq-file-name">
+                  <span class="qq-upload-file-selector qq-upload-file"></span>
+                  <span class="qq-edit-filename-icon-selector qq-btn qq-edit-filename-icon" aria-label="Edit filename"></span>
+                </div>
+                <input class="qq-edit-filename-selector qq-edit-filename" tabindex="0" type="text">
+                <span class="qq-upload-size-selector qq-upload-size"></span>
+                <button type="button" class="qq-btn qq-upload-delete-selector qq-upload-delete">
+                  <span class="qq-btn qq-delete-icon" aria-label="Delete"></span>
+                </button>
+                <button type="button" class="qq-btn qq-upload-pause-selector qq-upload-pause">
+                  <span class="qq-btn qq-pause-icon" aria-label="Pause"></span>
+                </button>
+                <button type="button" class="qq-btn qq-upload-continue-selector qq-upload-continue">
+                  <span class="qq-btn qq-continue-icon" aria-label="Continue"></span>
+                </button>
+              </div>
+            </li>
+          </ul>
+    
+          <dialog class="qq-alert-dialog-selector">
+            <div class="qq-dialog-message-selector"></div>
+            <div class="qq-dialog-buttons">
+              <button type="button" class="qq-cancel-button-selector">Close</button>
+            </div>
+          </dialog>
+    
+          <dialog class="qq-confirm-dialog-selector">
+            <div class="qq-dialog-message-selector"></div>
+            <div class="qq-dialog-buttons">
+              <button type="button" class="qq-cancel-button-selector">No</button>
+              <button type="button" class="qq-ok-button-selector">Yes</button>
+            </div>
+          </dialog>
+    
+          <dialog class="qq-prompt-dialog-selector">
+            <div class="qq-dialog-message-selector"></div>
+            <input type="text">
+            <div class="qq-dialog-buttons">
+              <button type="button" class="qq-cancel-button-selector">Cancel</button>
+              <button type="button" class="qq-ok-button-selector">Ok</button>
+            </div>
+          </dialog>
+        </div>
+      </div>`;
+      this.fineTemplate = $('<div/>')
+          .attr('id', 'qq-template')
+          .html(template);
+    }
+
+    /**
+     * build a div DOM element with id
+     * @return {Object} DOM Element to be injected into the form.
+     */
+    build() {
+      return this.markup('div', '', {id: this.config.name});
+    }
+
+    /**
+     * onRender callback
+     */
+    onRender() {
+
+      // we need to know where the server handler file located. I.e. where to we send the upload POST to?
+      // to set this, define controlConfig.file.handler in the formbuilder options
+      // defaults to '/upload'
+      var handler = this.classConfig.handler || '/upload';
+      delete this.classConfig.endpoint;
+      let config = $.extend({
+        request: {
+          endpoint: handler
+        },
+        deleteFile: {
+          enabled: true,
+          endpoint: handler
+        },
+        chunking: {
+          enabled: true,
+          concurrent: {
+            enabled: true
+          },
+          success: {
+            endpoint: handler + '?done'
+          }
+        },
+        resume: {
+          enabled: true
+        },
+        retry: {
+          enableAuto: true,
+          showButton: true
+        },
+        template: this.fineTemplate
+      }, this.classConfig);
+      $('#' + this.config.name).fineUploader(config);
+    }
+  }
+
+  // overload the file 'type' to use this uploader instead
+  controlClass.register('file', controlFineUpload);
+  return controlFineUpload;
+});


### PR DESCRIPTION
This plugin is designed to all the user to replace the default file upload control (which is pretty basic) with the more advanced file upload project from [fine uploader](https://fineuploader.com). This allows drag/drop, multiple file upload over ajax, pause, resume, delete etc etc.

Unfortunately they don't offer a CDN or anything, so if the user wants to use this, they will need to download it into their app & configure the control correctly. I provide inline docs that display if they don't configure the js or css options for the plugin correctly. They will already need to set up an upload handler anyway (I link to fine uploader's default php upload handler which is simple to set up), so file uploading in general is going to be targeted at a more intermediate user.

The only other option to simplify setup for users would be to either include the files they need in a `control_plugins/fineuploader/` folder, or alternatively set up a different `formbuilder-plugins` Github project & commit all this stuff to there - allowing us to link to javascript/css files using the [rawgit CDN](https://rawgit.com/).

Here's what it looks like:
![image](https://cloud.githubusercontent.com/assets/2694025/26536459/28727cbc-448b-11e7-940d-d5d65c05fdb3.png)
