### PR TITLE
Fineuploader error handling & reporting

### DIFF
--- a/src/js/control/file.fineuploader.js
+++ b/src/js/control/file.fineuploader.js
@@ -50,105 +50,105 @@ export default class controlFineUploader extends controlText {
    */
   configure() {
     this.js = this.classConfig.js || '//cdnjs.cloudflare.com/ajax/libs/file-uploader/5.14.2/jquery.fine-uploader/jquery.fine-uploader.min.js';
-    this.css = this.classConfig.css || '//cdnjs.cloudflare.com/ajax/libs/file-uploader/5.14.2/jquery.fine-uploader/fine-uploader-gallery.min.css';
+    this.css = [
+      this.classConfig.css || '//cdnjs.cloudflare.com/ajax/libs/file-uploader/5.14.2/jquery.fine-uploader/fine-uploader-gallery.min.css',
+      {
+        type: 'inline',
+        id: 'fineuploader-inline',
+        style: `
+          .qq-uploader .qq-error-message {
+            position: absolute;
+            left: 20%;
+            top: 20px;
+            width: 60%;
+            color: #a94442;
+            background: #f2dede;
+            border: solid 1px #ebccd1;
+            padding: 15px;
+            line-height: 1.5em;
+            text-align: center;
+            z-index: 99999;
+          }
+          .qq-uploader .qq-error-message span {
+            display: inline-block;
+            text-align: left;
+          }`
+      }
+    ];
     this.handler = this.classConfig.handler || '/upload';
     ['js', 'css', 'handler'].forEach(key => delete this.classConfig[key]);
 
     // fineuploader template that needs to be defined for the UI
     let template = this.classConfig.template || `
-        <div class="qq-uploader-selector qq-uploader qq-gallery" qq-drop-area-text="Drop files here">
-          <style type="text/css">
-            .qq-uploader .qq-error-message {
-              position: absolute;
-              left: 20%;
-              top: 20px;
-              width: 60%;
-              color: #a94442;
-              background: #f2dede;
-              border: solid 1px #ebccd1;
-              padding: 15px;
-              line-height: 1.5em;
-              text-align: center;
-              z-index: 99999;
-            }
-            .qq-uploader .qq-error-message span {
-              display: inline-block;
-              text-align: left;
-            }
-          </style>
-          <div class="qq-total-progress-bar-container-selector qq-total-progress-bar-container">
-            <div role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" class="qq-total-progress-bar-selector qq-progress-bar qq-total-progress-bar"></div>
-          </div>
-          <div class="qq-upload-drop-area-selector qq-upload-drop-area" qq-hide-dropzone>
-            <span class="qq-upload-drop-area-text-selector"></span>
-          </div>
-          <div class="qq-upload-button-selector qq-upload-button">
-            <div>Upload a file</div>
-          </div>
-          <span class="qq-drop-processing-selector qq-drop-processing">
-                    <span>Processing dropped files...</span>
-                    <span class="qq-drop-processing-spinner-selector qq-drop-processing-spinner"></span>
-                </span>
-          <ul class="qq-upload-list-selector qq-upload-list" role="region" aria-live="polite" aria-relevant="additions removals">
-            <li>
-              <span role="status" class="qq-upload-status-text-selector qq-upload-status-text"></span>
-              <div class="qq-progress-bar-container-selector qq-progress-bar-container">
-                <div role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" class="qq-progress-bar-selector qq-progress-bar"></div>
-              </div>
-              <span class="qq-upload-spinner-selector qq-upload-spinner"></span>
-              <div class="qq-thumbnail-wrapper">
-                <img class="qq-thumbnail-selector" qq-max-size="120" qq-server-scale>
-              </div>
-              <button type="button" class="qq-upload-cancel-selector qq-upload-cancel">X</button>
-              <button type="button" class="qq-upload-retry-selector qq-upload-retry">
-                <span class="qq-btn qq-retry-icon" aria-label="Retry"></span>
-                Retry
-              </button>
-    
-              <div class="qq-file-info">
-                <div class="qq-file-name">
-                  <span class="qq-upload-file-selector qq-upload-file"></span>
-                  <span class="qq-edit-filename-icon-selector qq-btn qq-edit-filename-icon" aria-label="Edit filename"></span>
-                </div>
-                <input class="qq-edit-filename-selector qq-edit-filename" tabindex="0" type="text">
-                <span class="qq-upload-size-selector qq-upload-size"></span>
-                <button type="button" class="qq-btn qq-upload-delete-selector qq-upload-delete">
-                  <span class="qq-btn qq-delete-icon" aria-label="Delete"></span>
-                </button>
-                <button type="button" class="qq-btn qq-upload-pause-selector qq-upload-pause">
-                  <span class="qq-btn qq-pause-icon" aria-label="Pause"></span>
-                </button>
-                <button type="button" class="qq-btn qq-upload-continue-selector qq-upload-continue">
-                  <span class="qq-btn qq-continue-icon" aria-label="Continue"></span>
-                </button>
-              </div>
-            </li>
-          </ul>
-    
-          <dialog class="qq-alert-dialog-selector">
-            <div class="qq-dialog-message-selector"></div>
-            <div class="qq-dialog-buttons">
-              <button type="button" class="qq-cancel-button-selector">Close</button>
-            </div>
-          </dialog>
-    
-          <dialog class="qq-confirm-dialog-selector">
-            <div class="qq-dialog-message-selector"></div>
-            <div class="qq-dialog-buttons">
-              <button type="button" class="qq-cancel-button-selector">No</button>
-              <button type="button" class="qq-ok-button-selector">Yes</button>
-            </div>
-          </dialog>
-    
-          <dialog class="qq-prompt-dialog-selector">
-            <div class="qq-dialog-message-selector"></div>
-            <input type="text">
-            <div class="qq-dialog-buttons">
-              <button type="button" class="qq-cancel-button-selector">Cancel</button>
-              <button type="button" class="qq-ok-button-selector">Ok</button>
-            </div>
-          </dialog>
+      <div class="qq-uploader-selector qq-uploader qq-gallery" qq-drop-area-text="Drop files here">
+        <div class="qq-total-progress-bar-container-selector qq-total-progress-bar-container">
+          <div role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" class="qq-total-progress-bar-selector qq-progress-bar qq-total-progress-bar"></div>
         </div>
+        <div class="qq-upload-drop-area-selector qq-upload-drop-area" qq-hide-dropzone>
+          <span class="qq-upload-drop-area-text-selector"></span>
+        </div>
+        <div class="qq-upload-button-selector qq-upload-button">
+          <div>Upload a file</div>
+        </div>
+        <span class="qq-drop-processing-selector qq-drop-processing">
+          <span>Processing dropped files...</span>
+          <span class="qq-drop-processing-spinner-selector qq-drop-processing-spinner"></span>
+        </span>
+        <ul class="qq-upload-list-selector qq-upload-list" role="region" aria-live="polite" aria-relevant="additions removals">
+          <li>
+            <span role="status" class="qq-upload-status-text-selector qq-upload-status-text"></span>
+            <div class="qq-progress-bar-container-selector qq-progress-bar-container">
+              <div role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" class="qq-progress-bar-selector qq-progress-bar"></div>
+            </div>
+            <span class="qq-upload-spinner-selector qq-upload-spinner"></span>
+            <div class="qq-thumbnail-wrapper">
+              <img class="qq-thumbnail-selector" qq-max-size="120" qq-server-scale>
+            </div>
+            <button type="button" class="qq-upload-cancel-selector qq-upload-cancel">X</button>
+            <button type="button" class="qq-upload-retry-selector qq-upload-retry">
+              <span class="qq-btn qq-retry-icon" aria-label="Retry"></span>
+              Retry
+            </button>
+            <div class="qq-file-info">
+              <div class="qq-file-name">
+                <span class="qq-upload-file-selector qq-upload-file"></span>
+                <span class="qq-edit-filename-icon-selector qq-btn qq-edit-filename-icon" aria-label="Edit filename"></span>
+              </div>
+              <input class="qq-edit-filename-selector qq-edit-filename" tabindex="0" type="text">
+              <span class="qq-upload-size-selector qq-upload-size"></span>
+              <button type="button" class="qq-btn qq-upload-delete-selector qq-upload-delete">
+                <span class="qq-btn qq-delete-icon" aria-label="Delete"></span>
+              </button>
+              <button type="button" class="qq-btn qq-upload-pause-selector qq-upload-pause">
+                <span class="qq-btn qq-pause-icon" aria-label="Pause"></span>
+              </button>
+              <button type="button" class="qq-btn qq-upload-continue-selector qq-upload-continue">
+                <span class="qq-btn qq-continue-icon" aria-label="Continue"></span>
+              </button>
+            </div>
+          </li>
+        </ul>
+        <dialog class="qq-alert-dialog-selector">
+          <div class="qq-dialog-message-selector"></div>
+          <div class="qq-dialog-buttons">
+            <button type="button" class="qq-cancel-button-selector">Close</button>
+          </div>
+        </dialog>
+        <dialog class="qq-confirm-dialog-selector">
+          <div class="qq-dialog-message-selector"></div>
+          <div class="qq-dialog-buttons">
+            <button type="button" class="qq-cancel-button-selector">No</button>
+            <button type="button" class="qq-ok-button-selector">Yes</button>
+          </div>
+        </dialog>
+        <dialog class="qq-prompt-dialog-selector">
+          <div class="qq-dialog-message-selector"></div>
+          <input type="text">
+          <div class="qq-dialog-buttons">
+            <button type="button" class="qq-cancel-button-selector">Cancel</button>
+            <button type="button" class="qq-ok-button-selector">Ok</button>
+          </div>
+        </dialog>
       </div>`;
     this.fineTemplate = $('<div/>')
       .attr('id', 'qq-template')

--- a/src/js/control/file.fineuploader.js
+++ b/src/js/control/file.fineuploader.js
@@ -69,6 +69,7 @@ export default class controlFineUploader extends controlText {
               padding: 15px;
               line-height: 1.5em;
               text-align: center;
+              z-index: 99999;
             }
             .qq-uploader .qq-error-message span {
               display: inline-block;
@@ -200,15 +201,18 @@ export default class controlFineUploader extends controlText {
       },
       callbacks: {
         onError: (id, name, errorReason, xhrOrXdr) => {
+          if (errorReason.slice(-1) != '.') {
+            errorReason += '.';
+          }
           let error = $('<div />')
             .addClass('qq-error-message')
-            .html(`<span>Error processing upload: <b>${name}</b>.<br />Reason: ${errorReason}.</span>`)
+            .html(`<span>Error processing upload: <b>${name}</b>.<br />Reason: ${errorReason}</span>`)
             .prependTo(wrapper.find('.qq-uploader'));
           setTimeout(() => {
             error.fadeOut(() => {
               error.remove();
             });
-          }, 5000);
+          }, 6000);
         }
       },
       template: this.fineTemplate

--- a/src/js/control/file.fineuploader.js
+++ b/src/js/control/file.fineuploader.js
@@ -57,6 +57,24 @@ export default class controlFineUploader extends controlText {
     // fineuploader template that needs to be defined for the UI
     let template = this.classConfig.template || `
         <div class="qq-uploader-selector qq-uploader qq-gallery" qq-drop-area-text="Drop files here">
+          <style type="text/css">
+            .qq-uploader .qq-error-message {
+              position: absolute;
+              left: 20%;
+              top: 20px;
+              width: 60%;
+              color: #a94442;
+              background: #f2dede;
+              border: solid 1px #ebccd1;
+              padding: 15px;
+              line-height: 1.5em;
+              text-align: center;
+            }
+            .qq-uploader .qq-error-message span {
+              display: inline-block;
+              text-align: left;
+            }
+          </style>
           <div class="qq-total-progress-bar-container-selector qq-total-progress-bar-container">
             <div role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" class="qq-total-progress-bar-selector qq-progress-bar qq-total-progress-bar"></div>
           </div>
@@ -141,13 +159,16 @@ export default class controlFineUploader extends controlText {
    * @return {Object} DOM Element to be injected into the form.
    */
   build() {
-    return this.markup('div', '', {id: this.config.name});
+    this.wrapper = this.markup('div', '', {id: this.config.name});
+    return this.wrapper;
   }
 
   /**
    * onRender callback
    */
   onRender() {
+    let wrapper = $(this.wrapper);
+
     // we need to know where the server handler file located. I.e. where to we send the upload POST to?
     // to set this, define controlConfig.file.handler in the formbuilder options
     // defaults to '/upload'
@@ -176,6 +197,19 @@ export default class controlFineUploader extends controlText {
       retry: {
         enableAuto: true,
         showButton: true
+      },
+      callbacks: {
+        onError: (id, name, errorReason, xhrOrXdr) => {
+          let error = $('<div />')
+            .addClass('qq-error-message')
+            .html(`<span>Error processing upload: <b>${name}</b>.<br />Reason: ${errorReason}.</span>`)
+            .prependTo(wrapper.find('.qq-uploader'));
+          setTimeout(() => {
+            error.fadeOut(() => {
+              error.remove();
+            });
+          }, 5000);
+        }
       },
       template: this.fineTemplate
     }, this.classConfig);

--- a/src/js/control/file.fineuploader.js
+++ b/src/js/control/file.fineuploader.js
@@ -160,8 +160,9 @@ export default class controlFineUploader extends controlText {
    * @return {Object} DOM Element to be injected into the form.
    */
   build() {
-    this.wrapper = this.markup('div', '', {id: this.config.name});
-    return this.wrapper;
+    this.input = this.markup('input', null, {type: 'hidden', name: this.config.name, id: this.config.name});
+    this.wrapper = this.markup('div', '', {id: this.config.name + '-wrapper'});
+    return [this.input, this.wrapper];
   }
 
   /**
@@ -169,6 +170,7 @@ export default class controlFineUploader extends controlText {
    */
   onRender() {
     let wrapper = $(this.wrapper);
+    let input = $(this.input);
 
     // we need to know where the server handler file located. I.e. where to we send the upload POST to?
     // to set this, define controlConfig.file.handler in the formbuilder options
@@ -213,11 +215,24 @@ export default class controlFineUploader extends controlText {
               error.remove();
             });
           }, 6000);
+        },
+        onStatusChange: (id, oldStatus, newStatus) => {
+          let uploads = wrapper.fineUploader('getUploads');
+
+          // retrieve an array of successfully uploaded filenames
+          let successful = [];
+          for (let upload of uploads) {
+            if (upload.status != 'upload successful') {
+              continue;
+            }
+            successful.push(upload.name);
+          }
+          input.val(successful.join(', '));
         }
       },
       template: this.fineTemplate
     }, this.classConfig);
-    $('#' + this.config.name).fineUploader(config);
+    wrapper.fineUploader(config);
   }
 }
 


### PR DESCRIPTION
Fineuploader silently fails by default when your server endpoint returns an error (wrong file type, too large, unwriteable upload dir etc). This PR adds support for displaying those errors in a user friendly way within the control. 

To support this I also upgraded controls to be able to define css rules with the `this.css` array (so it now supports both externally linked CSS, as well as inline css rules).

Tested in chrome, edge, and firefox.

There were also a couple of other more obscure bugs in fineuploader that are fixed in this PR.

My formbuilder demo won't compile in IE so couldn't test there, but it's pretty standard jQuery so can't see why it wouldn't work (then again ... we are talking about IE!)