### PR TITLE
Bring formbuilder-formrender + form data together

### DIFF
--- a/demo/assets/css/demoRender.css
+++ b/demo/assets/css/demoRender.css
@@ -1,0 +1,34 @@
+html,
+body {
+  height: 100%;
+}
+
+body {
+  background-color: #f2f2f2;
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==);
+  font-family: Helvetica, 'Helvetica Neue', Arial, sans-serif;
+}
+
+.template-textarea-wrap {
+  display: block !important;
+}
+
+.content {
+  margin: auto;
+  width: 100%;
+  max-width: 1280px;
+  padding-top: 1em;
+}
+
+.form-rendered .render-wrap {
+  display: block;
+}
+
+#edit-form {
+  display: none;
+  float: right;
+}
+
+.form-rendered #edit-form {
+  display: block;
+}

--- a/demo/assets/js/demoRender.js
+++ b/demo/assets/js/demoRender.js
@@ -1,0 +1,122 @@
+var frInstance;
+var setFormData ;
+var updatedData;
+
+jQuery(function($) {  
+  var fbOptions = {
+    controlConfig: {
+      'textarea.tinymce': {
+          //selector: 'textarea', This transforms ALL textareas
+          branding: false,
+          encoding: "xml",
+          menubar: 'edit insert format table',
+          plugins: 'preview searchreplace autolink link table lists textcolor colorpicker',
+          toolbar: 'formatselect | bold italic forecolor backcolor | link | alignleft aligncenter alignright alignjustify  | numlist bullist outdent indent  | preview'
+          //readonly: true
+         
+      }
+    },
+  }; 
+
+  //fbOptions.formData = setFormData;  
+  //frInstance = $('#renderMe').formRender(fbOptions);
+
+  //autocomplete
+  document.getElementById('set-autocomplete').addEventListener('click', function() {
+    setFormData = '[{"type":"autocomplete","label":"Autocomplete","className":"form-control","name":"autocomplete-1526094918549","requireValidOption":true,"values":[{"label":"Option 1","value":"option-1"},{"label":"Option 2","value":"option-2"},{"label":"Option 3","value":"option-3"}],"userData":["option-1"]}]';  
+    resetFR();  
+  });
+
+  //hidden
+  document.getElementById('set-hidden').addEventListener('click', function() {
+    setFormData = '[{"type":"hidden","name":"hidden-1526098170460","userData":["Josh"]}]';  
+    resetFR();  
+  });
+
+  //select
+  document.getElementById('set-select').addEventListener('click', function() {
+    setFormData = '[{"type":"select","label":"Select","className":"form-control","name":"select-1526098313742","multiple":true,"values":[{"label":"Option 1","value":"option-1"},{"label":"Option 2","value":"option-2"},{"label":"Option 3","value":"option-3"}],"userData":["option-1","option-3"]}]';  
+    resetFR();  
+  });
+
+    //checkbox-group
+    document.getElementById('set-checkbox-group').addEventListener('click', function() {
+      setFormData = '[{"type":"checkbox-group","label":"Checkbox Group","name":"checkbox-group-1526095813035","other":true,"values":[{"label":"Option 1","value":"option-1"},{"label":"2","value":"2"}],"userData":["option-1","Bilbo \\\"baggins\\\""]}]';
+      resetFR();  
+    });
+
+      //radio-group
+  document.getElementById('set-radio-group').addEventListener('click', function() {
+    setFormData = '[{"type":"radio-group","label":"Radio Group","name":"radio-group-1526098461173","other":true,"values":[{"label":"Option 1","value":"option-1"},{"label":"Option 2","value":"option-2"},{"label":"Option 3","value":"option-3"}],"userData":["option-3"]}]';  
+    resetFR();  
+  });
+
+    //text
+    document.getElementById('set-text').addEventListener('click', function() {
+      setFormData = '[{"type":"text","label":"Text Field","name":"text-1526099104236","subtype":"text","userData":["Text"]}]';  
+      resetFR();  
+    });
+
+      //password
+    document.getElementById('set-password').addEventListener('click', function() {
+      setFormData = '[{"type":"text","label":"Text Field","name":"text-1526099104236","subtype":"password","userData":["Text"]}]';  
+      resetFR();  
+    });
+   
+    //email
+    document.getElementById('set-email').addEventListener('click', function() {
+      setFormData = '[{"type":"text","label":"Text Field","name":"text-1526099104236","subtype":"email","userData":["a@a.com"]}]';  
+      resetFR();  
+    });
+
+    //color
+    document.getElementById('set-color').addEventListener('click', function() {
+      setFormData = '[{"type":"text","label":"Text Field","name":"text-1526099104236","subtype":"color","userData":["#00ff00"]}]';  
+      resetFR();  
+    });
+
+    //tel
+    document.getElementById('set-tel').addEventListener('click', function() {
+      setFormData = '[{"type":"text","label":"Text Field","name":"text-1526099104236","subtype":"tel","userData":["123-456-7890"]}]';  
+      resetFR();  
+    });
+
+      //date
+  document.getElementById('set-date').addEventListener('click', function() {
+    setFormData = '[{"type":"date","label":"Date Field","className":"form-control","name":"date-1526096579821","userData":["2018-01-01"]}]'; 
+    resetFR();  
+  });
+
+    //number
+    document.getElementById('set-number').addEventListener('click', function() {
+      setFormData = '[{"type":"number","label":"Number","className":"form-control","name":"number-1526099204594","min":"1","max":"3","step":".2","userData":["1.1"]}]';  
+      resetFR();  
+    });
+
+      //textarea
+  document.getElementById('set-textarea').addEventListener('click', function() {
+    setFormData = '[{"type":"textarea","label":"Text Area","className":"form-control","name":"textarea-1526099273610","subtype":"textarea","userData":["Tennessee Welcomes You!"]}]';
+    resetFR();  
+  });
+
+    //textarea-tinymce
+    document.getElementById('set-textarea-tinymce').addEventListener('click', function() {
+      setFormData = '[{"type":"textarea","subtype":"tinymce","label":"Text Area","className":"form-control","name":"textarea-1526099273610","userData":["&lt;p&gt;&lt;span style=&quot;color: #339966;&quot;&gt;It&#39;s a great place&lt;/span&gt;&lt;/p&gt;"]}]';
+      resetFR();  
+    });   
+
+    document.getElementById('showdata').addEventListener('click', function() {
+      $("#showData").html(JSON.stringify(frInstance.userData)); 
+    });
+
+  function resetFR(){
+    fbOptions.formData = setFormData;  
+
+    //fbOptions.formData = cleanData(fbOptions.formData);
+    frInstance = $('#renderMe').formRender(fbOptions);  
+    $("#showData").html('');  
+  }
+
+   
+
+});

--- a/demo/indexRender.html
+++ b/demo/indexRender.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <link rel="stylesheet" type="text/css" href="assets/css/demoRender.css">
+  <link rel="stylesheet" type="text/css" media="screen" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" type="text/css" media="screen" href="https://cdnjs.cloudflare.com/ajax/libs/rateYo/2.3.1/jquery.rateyo.min.css">
+
+  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
+  <title>jQuery formBuilder/formRender Demo</title>
+</head>
+
+<body>
+  <div class="content">
+    
+    <div class="action-buttons">     
+      <label>Actions</label>
+      <button id="set-autocomplete" type="button">Autocomplete</button>
+      <button id="set-hidden" type="button">Hidden</button>
+      <button id="set-select" type="button">Select</button>
+      <button id="set-checkbox-group" type="button">Checkbox Group</button>
+      <button id="set-radio-group" type="button">Radio Group</button>
+      <button id="set-text" type="button">Text</button>
+      <button id="set-password" type="button">Password</button>
+      <button id="set-email" type="button">Email</button>
+      <button id="set-color" type="button">Color</button>
+      <button id="set-tel" type="button">Telephone</button> 
+      <button id="set-date" type="button">Date</button>
+      <button id="set-number" type="button">Number</button>
+      <button id="set-textarea" type="button">Textarea</button>
+      <button id="set-textarea-tinymce" type="button">Textarea-TinyMCE</button> 
+      <button id="showdata" type="button" class="btn btn-sm btn-info">Show Data</button>      
+      
+  </div>
+
+    <div id="renderMe"></div>
+
+    <div id="showData"></div>
+
+  <script src="assets/js/vendor.js"></script>
+  <script src="assets/js/form-render.min.js"></script>
+  <script src="https://cdn.tinymce.com/4/tinymce.min.js"></script>
+  <script src="assets/js/demoRender.js"></script>  
+</body>
+
+</html>

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -7,7 +7,7 @@ export const defaultOptions = {
     'button',
     'checkbox',
     'checkbox-group',
-    'date',    
+    'date',
     'file',
     'header',
     'hidden',
@@ -47,8 +47,8 @@ export const defaultOptions = {
   inputSets: [],
   replaceFields: [],
   roles: {
-    1: 'Administrator'  
-  },  
+    1: 'Administrator'
+  },
   notify: {
     error: message => console.error(message),
     success: message => console.log(message),
@@ -121,7 +121,7 @@ export const defaultI18n = {
       inlineDesc: 'Display {type} inline',
       label: 'Label',
       labelEmpty: 'Field Label cannot be empty',
-      limitRole: 'Limit access to one or more of the following roles:',      
+      limitRole: 'Limit access to one or more of the following roles:',   
       mandatory: 'Mandatory',
       maxlength: 'Max Length',
       minOptionMessage: 'This field requires a minimum of 2 options',

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -7,12 +7,12 @@ export const defaultOptions = {
     'button',
     'checkbox',
     'checkbox-group',
-    'date',
+    'date',    
     'file',
     'header',
     'hidden',
+    'number',    
     'paragraph',
-    'number',
     'radio-group',
     'select',
     'text',
@@ -22,7 +22,7 @@ export const defaultOptions = {
   // Array of fields to disable
   disableFields: [],
   disabledAttrs: [],
-  disabledActionButtons: [],
+  disabledActionButtons: [], // save,data,clear
   disabledFieldButtons: {},
   editOnAdd: false,
   // Uneditable fields or other content you would like to appear
@@ -47,8 +47,8 @@ export const defaultOptions = {
   inputSets: [],
   replaceFields: [],
   roles: {
-    1: 'Administrator',
-  },
+    1: 'Administrator'  
+  },  
   notify: {
     error: message => console.error(message),
     success: message => console.log(message),
@@ -111,9 +111,9 @@ export const defaultI18n = {
       enableOtherMsg: 'Let users to enter an unlisted option',
       fieldNonEditable: 'This field cannot be edited.',
       fieldRemoveWarning: 'Are you sure you want to remove this field?',
-      fileUpload: 'File Upload',
+      fileUpload: 'File Upload',         
       formUpdated: 'Form Updated',
-      getStarted: 'Drag a field from the right to this area',
+      getStarted: 'Drag or click a field from the right to this area',
       header: 'Header',
       hide: 'Edit',
       hidden: 'Hidden Input',
@@ -121,7 +121,7 @@ export const defaultI18n = {
       inlineDesc: 'Display {type} inline',
       label: 'Label',
       labelEmpty: 'Field Label cannot be empty',
-      limitRole: 'Limit access to one or more of the following roles:',
+      limitRole: 'Limit access to one or more of the following roles:',      
       mandatory: 'Mandatory',
       maxlength: 'Max Length',
       minOptionMessage: 'This field requires a minimum of 2 options',
@@ -157,6 +157,7 @@ export const defaultI18n = {
       removeOption: 'Remove Option',
       remove: '&#215;',
       required: 'Required',
+      requireValidOption: 'Only accept a pre-defined Option',     
       richText: 'Rich Text Editor',
       roles: 'Access',
       rows: 'Rows',

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -121,7 +121,7 @@ export const defaultI18n = {
       inlineDesc: 'Display {type} inline',
       label: 'Label',
       labelEmpty: 'Field Label cannot be empty',
-      limitRole: 'Limit access to one or more of the following roles:',   
+      limitRole: 'Limit access to one or more of the following roles:',  
       mandatory: 'Mandatory',
       maxlength: 'Max Length',
       minOptionMessage: 'This field requires a minimum of 2 options',

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -111,7 +111,7 @@ export const defaultI18n = {
       enableOtherMsg: 'Let users to enter an unlisted option',
       fieldNonEditable: 'This field cannot be edited.',
       fieldRemoveWarning: 'Are you sure you want to remove this field?',
-      fileUpload: 'File Upload',         
+      fileUpload: 'File Upload',
       formUpdated: 'Form Updated',
       getStarted: 'Drag or click a field from the right to this area',
       header: 'Header',

--- a/src/js/control.js
+++ b/src/js/control.js
@@ -25,7 +25,7 @@ export default class control {
     }
 
     // process config - extract standard properties
-    let properties = ['label', 'description', 'subtype', 'required']
+    let properties = ['label', 'description', 'subtype', 'required','disabled']
     for (let prop of properties) {
       this[prop] = config[prop]
       delete config[prop]
@@ -60,6 +60,11 @@ export default class control {
     if (this.required) {
       config['required'] = 'required'
       config['aria-required'] = 'true'
+    }
+
+    // Allow setting disabled flag
+    if(this.disabled){
+      config['disabled'] = 'disabled' 
     }
     this.config = config
     this.configure()

--- a/src/js/control/autocomplete.js
+++ b/src/js/control/autocomplete.js
@@ -12,7 +12,7 @@ export default class controlAutocomplete extends control {
    */
   build() {
     let {values, type, ...data} = this.config;
-    const keyboardNav = (e) => {     
+    const keyboardNav = (e) => {
       const list = e.target.nextSibling.nextSibling;
       const hiddenField = e.target.nextSibling;
       let activeOption = this.getActiveOption(list);

--- a/src/js/control/autocomplete.js
+++ b/src/js/control/autocomplete.js
@@ -229,7 +229,7 @@ export default class controlAutocomplete extends control {
    * @return {Object} - is the option in the pre defined list
    */
   isOptionValid(list,value){
-    const options = list.querySelectorAll('li'); 
+    const options = list.querySelectorAll('li');  
     let validValue = false;
     for (let i = 0; i < options.length; i++) {
       if(options[i].innerHTML === value){
@@ -247,19 +247,21 @@ export default class controlAutocomplete extends control {
   onRender(evt) {
     // Set userData if available
     if(this.config.userData){  
-      let id = $('#'+this.config.name).attr('id');
+      let $el = $('#'+this.config.name);
+      let $options = $el.next();
+            
       let preSelectedOption = this.config.userData[0];
- 
-      const list = document.getElementById(id).nextSibling;
-      let selectedOption= null;
+      let selectedOption = null;
 
-      $('#' +id + '-list' + ' li').each(function(){   
-      // eslint-disable-next-line no-invalid-this             
+      $options.find('li').each(function(){   
+      // eslint-disable-next-line no-invalid-this
         if($(this).attr('value') === preSelectedOption){
-       // eslint-disable-next-line no-invalid-this          
+          // eslint-disable-next-line no-invalid-this          
           selectedOption = $(this).get(0);                             
+          return;
         }
-      }); 
+      });      
+           
      // If the option was not set, and configuration says it doesn't have to be pre-defined, set the value
      if(selectedOption === null){
        if(this.config.requireValidOption){
@@ -267,14 +269,16 @@ export default class controlAutocomplete extends control {
          return;
        }else{
          // Set it to whatever the value is
-        $('#' + id).prev().val(this.config.userData[0]);
+        $el.prev().val(this.config.userData[0]);
         return;         
        }
      }     
 
-      $('#' + id).prev().val(selectedOption.innerHTML);
-      $('#' + id).val(selectedOption.getAttribute('value'));
-      
+      $el.prev().val(selectedOption.innerHTML);
+      $el.val(selectedOption.getAttribute('value'));
+                
+      const list =  $el.next().get(0);
+
       if (list.style.display === 'none') {
         this.showList(list, selectedOption);
       } else {

--- a/src/js/control/autocomplete.js
+++ b/src/js/control/autocomplete.js
@@ -12,7 +12,7 @@ export default class controlAutocomplete extends control {
    */
   build() {
     let {values, type, ...data} = this.config;
-    const keyboardNav = (e) => {
+    const keyboardNav = (e) => {     
       const list = e.target.nextSibling.nextSibling;
       const hiddenField = e.target.nextSibling;
       let activeOption = this.getActiveOption(list);
@@ -40,6 +40,16 @@ export default class controlAutocomplete extends control {
               this.showList(list, activeOption);
             } else {
               this.hideList(list);
+            }
+          }
+          else{    
+            // Don't allow a value not in the list   
+            if(this.config.requireValidOption)  
+            {
+              if(!this.isOptionValid(list,e.target.value)){
+                e.target.value = ''; 
+                e.target.nextSibling.value = '';  
+              }
             }
           }
           e.preventDefault();
@@ -73,6 +83,15 @@ export default class controlAutocomplete extends control {
         setTimeout(() => {
           evt.target.nextSibling.nextSibling.style.display = 'none';
         }, 200);
+        // Validate the option entered exists
+        if(this.config.requireValidOption)  
+        {
+          const list = evt.target.nextSibling.nextSibling;    
+          if(!this.isOptionValid(list,evt.target.value)){
+            evt.target.value = ''; 
+            evt.target.nextSibling.value = '';   
+          }
+        }   
       },
       input: (evt) => {
         const list = evt.target.nextSibling.nextSibling;
@@ -192,22 +211,78 @@ export default class controlAutocomplete extends control {
    * @param {Object} selectedOption - option - 'li' element - to be selected in autocomplete list
    */
   selectOption(list, selectedOption) {
-    const options = list.querySelectorAll('li');
-    options.forEach((option)=>{
-      option.classList.remove('active-option');
-    });
+    const options = list.querySelectorAll('li'); 
+    // --Fix for IE11
+    for (let i = 0; i < options.length; i++) {
+      options[i].classList.remove('active-option');
+    }
     if (selectedOption) {
       selectedOption.classList.add('active-option');
     }
   }
+   
 
   /**
-   * When the element is rendered into the DOM, execute the following code to initialise it
-   * @param {Object} evt - event
+   * Is the value in the autocomplete field in the pre-defined Options list?
+   * @param {Object} list - list of autocomplete options
+   * @param {Object} value -value trying to be set
+   * @return {Object} - is the option in the pre defined list
    */
+  isOptionValid(list,value){
+    const options = list.querySelectorAll('li'); 
+    let validValue = false;
+    for (let i = 0; i < options.length; i++) {
+      if(options[i].innerHTML == value){
+        validValue = true;
+        break;
+      }
+    }
+    return validValue;  
+  }
+  
+  /**
+   * onRender callback
+   * @param {Object} evt
+   */  
   onRender(evt) {
+    // Set userData if available
+    if(this.config.userData){  
+      let id = $('#'+this.config.name).attr('id');
+      let preSelectedOption = this.config.userData[0];
+ 
+      const list = document.getElementById(id).nextSibling;
+      let selectedOption;
+
+      $('#' +id + '-list' + ' li').each(function(){   
+      // eslint-disable-next-line no-invalid-this             
+        if($(this).attr('value') == preSelectedOption){
+       // eslint-disable-next-line no-invalid-this          
+          selectedOption = $(this).get(0);                             
+        }
+      }); 
+     // If the option was not defined, and configuration says it doesn't have to be pre-defined, set the value
+     if(selectedOption == undefined){
+       if(this.config.requireValidOption){
+         // Don't allow
+         return;
+       }else{
+         // Set it to whatever the value is
+        $('#' + id).prev().val(this.config.userData[0]);
+        return;         
+       }
+     }     
+
+      $('#' + id).prev().val(selectedOption.innerHTML);
+      $('#' + id).val(selectedOption.getAttribute('value'));
+      
+      if (list.style.display === 'none') {
+        this.showList(list, selectedOption);
+      } else {
+        this.hideList(list);
+      }    
+         
+    }
   }
 }
 
-// register tinymce as a richtext control
 control.register('autocomplete', controlAutocomplete);

--- a/src/js/control/autocomplete.js
+++ b/src/js/control/autocomplete.js
@@ -232,7 +232,7 @@ export default class controlAutocomplete extends control {
     const options = list.querySelectorAll('li'); 
     let validValue = false;
     for (let i = 0; i < options.length; i++) {
-      if(options[i].innerHTML == value){
+      if(options[i].innerHTML === value){
         validValue = true;
         break;
       }
@@ -251,17 +251,17 @@ export default class controlAutocomplete extends control {
       let preSelectedOption = this.config.userData[0];
  
       const list = document.getElementById(id).nextSibling;
-      let selectedOption;
+      let selectedOption= null;
 
       $('#' +id + '-list' + ' li').each(function(){   
       // eslint-disable-next-line no-invalid-this             
-        if($(this).attr('value') == preSelectedOption){
+        if($(this).attr('value') === preSelectedOption){
        // eslint-disable-next-line no-invalid-this          
           selectedOption = $(this).get(0);                             
         }
       }); 
-     // If the option was not defined, and configuration says it doesn't have to be pre-defined, set the value
-     if(selectedOption == undefined){
+     // If the option was not set, and configuration says it doesn't have to be pre-defined, set the value
+     if(selectedOption === null){
        if(this.config.requireValidOption){
          // Don't allow
          return;

--- a/src/js/control/hidden.js
+++ b/src/js/control/hidden.js
@@ -16,6 +16,16 @@ export default class controlHidden extends control {
       layout: 'hidden'
     };
   }
+
+    /**
+   * onRender callback
+   */
+  onRender() {
+    // Set userData if available
+    if(this.config.userData){       
+      $('#'+this.config.name).val(this.config.userData[0]);        
+    }
+  }
 }
 
 // register the following controls

--- a/src/js/control/paragraph.js
+++ b/src/js/control/paragraph.js
@@ -31,4 +31,4 @@ export default class controlParagraph extends control {
 // register the following controls
 control.register(['paragraph', 'header'], controlParagraph);
 control.register(['p', 'address', 'blockquote', 'canvas', 'output'], controlParagraph, 'paragraph');
-control.register(['h1', 'h2', 'h3'], controlParagraph, 'header');
+control.register(['h1', 'h2', 'h3','h4'], controlParagraph, 'header');

--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -208,20 +208,22 @@ export default class controlSelect extends control {
         selectedOptions.push(this.config.userData[i]);
       } 
 
-      if(this.config.type == 'select')
+      if(this.config.type === 'select')
       {
          $('#'+this.config.name).val(selectedOptions).prop('selected',true);  
       }
-      else if(this.config.type == 'checkbox-group' || this.config.type == 'radio-group'){
+      else if(this.config.type === 'checkbox-group' || this.config.type === 'radio-group'){
         $('.field-' + this.config.name + ' :input').each(function(){
           // eslint-disable-next-line no-invalid-this          
           if($(this).hasClass('other-val'))
+          {
             return;
+          } 
 
           let foundMatch = false;
           for(let i = 0 ; i < selectedOptions.length ; i++){
             // eslint-disable-next-line no-invalid-this            
-            if($(this).val() == selectedOptions[i]){
+            if($(this).val() === selectedOptions[i]){
             // eslint-disable-next-line no-invalid-this      
               $(this).val(selectedOptions[i]).prop('checked',true);
               foundMatch = true;
@@ -236,8 +238,10 @@ export default class controlSelect extends control {
             let id = $(this).attr('id');            
             if(id.indexOf('-other') !== -1){
               // If there is no value to set, don't check the other option
-              if(selectedOptions.length == 0)
-                return;
+              if(selectedOptions.length === 0)
+             {
+               return;
+             }
               // eslint-disable-next-line no-invalid-this  
               $(this).val(selectedOptions[0]);
               // eslint-disable-next-line no-invalid-this    

--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -195,6 +195,63 @@ export default class controlSelect extends control {
       otherInputValue.style.display = 'none';
     }
   }
+
+
+    /**
+   * onRender callback
+   */
+  onRender() {
+    // Set userData if available
+    if(this.config.userData){ 
+      let selectedOptions = [];
+      for (let i = 0; i < this.config.userData.length; i++) {
+        selectedOptions.push(this.config.userData[i]);
+      } 
+
+      if(this.config.type == 'select')
+      {
+         $('#'+this.config.name).val(selectedOptions).prop('selected',true);  
+      }
+      else if(this.config.type == 'checkbox-group' || this.config.type == 'radio-group'){
+        $('.field-' + this.config.name + ' :input').each(function(){
+          // eslint-disable-next-line no-invalid-this          
+          if($(this).hasClass('other-val'))
+            return;
+
+          let foundMatch = false;
+          for(let i = 0 ; i < selectedOptions.length ; i++){
+            // eslint-disable-next-line no-invalid-this            
+            if($(this).val() == selectedOptions[i]){
+            // eslint-disable-next-line no-invalid-this      
+              $(this).val(selectedOptions[i]).prop('checked',true);
+              foundMatch = true;
+              selectedOptions.splice(i,1);// Remove this item from the list
+              break;
+            }
+          }
+
+          // Did not find a match for the selectedOption, see if this is an "other"
+          if(!foundMatch){
+            // eslint-disable-next-line no-invalid-this  
+            let id = $(this).attr('id');            
+            if(id.indexOf('-other') !== -1){
+              // If there is no value to set, don't check the other option
+              if(selectedOptions.length == 0)
+                return;
+              // eslint-disable-next-line no-invalid-this  
+              $(this).val(selectedOptions[0]);
+              // eslint-disable-next-line no-invalid-this    
+              $(this).trigger('click');
+              // set the other value
+              $('#' + id + '-value').val(selectedOptions[0]);
+            }
+          }
+        });
+      }
+               
+    }
+  }
+
 }
 
 // register this control for the following types & text subtypes

--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -204,10 +204,8 @@ export default class controlSelect extends control {
     // Set userData if available
     if(this.config.userData){ 
       let selectedOptions = [];
-      for (let i = 0; i < this.config.userData.length; i++) {
-        selectedOptions.push(this.config.userData[i]);
-      } 
-
+      selectedOptions = this.config.userData.slice(0);
+      
       if(this.config.type === 'select')
       {
          $('#'+this.config.name).val(selectedOptions).prop('selected',true);  

--- a/src/js/control/text.js
+++ b/src/js/control/text.js
@@ -24,7 +24,7 @@ export default class controlText extends control {
    * build a text DOM element, supporting other jquery text form-control's
    * @return {Object} DOM Element to be injected into the form.
    */
-  build() { 
+  build() {
     return this.markup('input', null, this.config);
   }
 

--- a/src/js/control/text.js
+++ b/src/js/control/text.js
@@ -24,8 +24,18 @@ export default class controlText extends control {
    * build a text DOM element, supporting other jquery text form-control's
    * @return {Object} DOM Element to be injected into the form.
    */
-  build() {
+  build() { 
     return this.markup('input', null, this.config);
+  }
+
+  /**
+   * onRender callback
+   */
+  onRender() {
+    // Set userData if available
+    if(this.config.userData){       
+      $('#'+this.config.name).val(this.config.userData[0]);        
+    }
   }
 }
 

--- a/src/js/control/textarea.js
+++ b/src/js/control/textarea.js
@@ -30,6 +30,16 @@ export default class controlTextarea extends control {
   }
 
   /**
+  * onRender callback
+  */
+  onRender() {
+    // Set userData if available
+    if(this.config.userData){       
+      $('#'+this.config.name).val(this.config.userData[0]);        
+    }
+  }
+    
+  /**
    * extend the default events to add a prerender for textareas
    * @param {String} eventType
    * @return {Function} prerender function

--- a/src/js/control/textarea.tinymce.js
+++ b/src/js/control/textarea.tinymce.js
@@ -84,8 +84,9 @@ export default class controlTinymce extends controlTextarea {
     window.tinymce.init(options);
     
     // Set userData
-    if(this.config.userData)
+    if(this.config.userData){
       window.tinymce.editors[this.id].setContent(this.parsedHtml(this.config.userData[0]));
+    }
   }
 }
 

--- a/src/js/control/textarea.tinymce.js
+++ b/src/js/control/textarea.tinymce.js
@@ -22,7 +22,7 @@ export default class controlTinymce extends controlTextarea {
    * configure the tinymce editor requirements
    */
   configure() {
-    // this.js = ['//cdn.tinymce.com/4/tinymce.min.js'];
+    this.js = ['//cdn.tinymce.com/4/tinymce.min.js'];
 
     // additional javascript config
     if (this.classConfig.js) {

--- a/src/js/control/textarea.tinymce.js
+++ b/src/js/control/textarea.tinymce.js
@@ -78,8 +78,7 @@ export default class controlTinymce extends controlTextarea {
 
     // define options & allow them to be overwritten in the class config
     let options = $.extend(this.editorOptions, this.classConfig);
-    options.target = this.field;  
-   
+    options.target = this.field;
     // initialise the editor
     window.tinymce.init(options);
     

--- a/src/js/control/textarea.tinymce.js
+++ b/src/js/control/textarea.tinymce.js
@@ -22,7 +22,7 @@ export default class controlTinymce extends controlTextarea {
    * configure the tinymce editor requirements
    */
   configure() {
-    this.js = ['//cdn.tinymce.com/4/tinymce.min.js'];
+    // this.js = ['//cdn.tinymce.com/4/tinymce.min.js'];
 
     // additional javascript config
     if (this.classConfig.js) {
@@ -60,6 +60,10 @@ export default class controlTinymce extends controlTextarea {
   build() {
     let {value = '', ...attrs} = this.config;
     this.field = this.markup('textarea', this.parsedHtml(value), attrs);
+    // Make the editor read only if disabled is set on the textarea
+    if(attrs.disabled){
+      this.editorOptions.readonly = true;    
+    }
     return this.field;
   }
 
@@ -74,10 +78,14 @@ export default class controlTinymce extends controlTextarea {
 
     // define options & allow them to be overwritten in the class config
     let options = $.extend(this.editorOptions, this.classConfig);
-    options.target = this.field;
-
+    options.target = this.field;  
+   
     // initialise the editor
     window.tinymce.init(options);
+    
+    // Set userData
+    if(this.config.userData)
+      window.tinymce.editors[this.id].setContent(this.parsedHtml(this.config.userData[0]));
   }
 }
 

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -424,7 +424,7 @@ const FormBuilder = function(opts, element) {
     let valueField = !utils.inArray(type, noValFields)
 
     const typeAttrsMap = {
-      autocomplete: defaultAttrs.concat(['options']),
+      autocomplete: defaultAttrs.concat(['options','requireValidOption']),
       button: ['label', 'subtype', 'style', 'className', 'name', 'value', 'access'],
       checkbox: [
         'required',
@@ -564,8 +564,19 @@ const FormBuilder = function(opts, element) {
           first: ' ',
           second: i18n.selectionsMessage,
         })
+      }     
+    }
+
+    if(type === 'autocomplete'){     
+      advFieldMap['requireValidOption'] = () => {
+        return boolAttribute('requireValidOption', values, {
+          first: ' ',
+          second: i18n.requireValidOption,
+        })
       }
     }
+
+
 
     Object.keys(fieldAttrs).forEach(index => {
       let attr = fieldAttrs[index]

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -264,10 +264,6 @@ class FormRender {
         for (let i = 0; i < userDataFields.length; i++){
           userDataFields[i].name = userDataFields[i].name.replace(/[\[\]']+/g,'');
         }                 
-        // console.log("Definition");
-        // console.log(definitionFields);
-        // console.log("User Data");
-        // console.log(userDataFields);
 
         for (let i = 0; i < definitionFields.length; i++){
           let definitionField = definitionFields[i];           
@@ -284,30 +280,19 @@ class FormRender {
           for (let j = 0; j < userDataFields.length; j++){            
             if(definitionField.name == userDataFields[j].name){
               foundData = true;
-              // var test = userDataFields[j].value.replace(/'/g, "&#x27;").replace(/"/g, '&#x22;').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
               userData.push(userDataFields[j].value); 
             }else{
               // We started finding data but now we moved into another element
               if(foundData)
                 break;
             }
-          }
-             
+          }             
           if(userData.length == 0){
-            // console.log('No data for ' + definitionField.name);
             continue;
           }           
-          
-          // console.log("Data found for " + definitionField.name);
-          // console.log(userData);
           definitionField.userData = userData;
-          // console.log("Merged data:");
-          // console.log(mergedField);     
           mergedData.push(definitionField);    
         }      
-      
-        // console.log(options.formData);
-        // console.log('Merged Data');  
         return mergedData;
       }
     }

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -240,10 +240,79 @@ class FormRender {
 }
 
 ;(function($) {
-  $.fn.formRender = function(options) {
-    let elems = this
+  $.fn.formRender = function(options) {    
+    let $elems = this
     let formRender = new FormRender(options)
-    elems.each(i => formRender.render(elems[i]))
+    $elems.each(i => formRender.render($elems[i]))   
+    
+    let instance = {     
+      get userData() {
+        let mergedData = [];
+
+        let definitionFields = JSON.parse(options.formData);
+        // Check if tinyMCE needs to save data into textarea first
+        for (let i = 0; i < definitionFields.length; i++){
+          if(definitionFields[i].subtype == 'tinymce'){
+            window.tinyMCE.triggerSave();
+            break;
+          }
+        }        
+
+        // Serialize the user data
+        let userDataFields = $('#' + $elems.attr('id') + ' :input').serializeArray();
+        // Replace ending [] to match names
+        for (let i = 0; i < userDataFields.length; i++){
+          userDataFields[i].name = userDataFields[i].name.replace(/[\[\]']+/g,'');
+        }                 
+        // console.log("Definition");
+        // console.log(definitionFields);
+        // console.log("User Data");
+        // console.log(userDataFields);
+
+        for (let i = 0; i < definitionFields.length; i++){
+          let definitionField = definitionFields[i];           
+          // Skip fields that have no name--Likely these are fields that do not hold data(h1,p)
+          if(definitionField.name == undefined)
+            continue;
+          // Skip disabled fields -- This will not have user data available
+          if(definitionField.disabled)
+            continue;
+          
+          // Pull all data for the definition
+          let userData = [];        
+          let foundData = false;
+          for (let j = 0; j < userDataFields.length; j++){            
+            if(definitionField.name == userDataFields[j].name){
+              foundData = true;
+              // var test = userDataFields[j].value.replace(/'/g, "&#x27;").replace(/"/g, '&#x22;').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+              userData.push(userDataFields[j].value); 
+            }else{
+              // We started finding data but now we moved into another element
+              if(foundData)
+                break;
+            }
+          }
+             
+          if(userData.length == 0){
+            // console.log('No data for ' + definitionField.name);
+            continue;
+          }           
+          
+          // console.log("Data found for " + definitionField.name);
+          // console.log(userData);
+          definitionField.userData = userData;
+          // console.log("Merged data:");
+          // console.log(mergedField);     
+          mergedData.push(definitionField);    
+        }      
+      
+        // console.log(options.formData);
+        // console.log('Merged Data');  
+        return mergedData;
+      }
+    }
+
+    return instance
   }
 
   /**
@@ -256,8 +325,8 @@ class FormRender {
     options.formData = data
     options.dataType = typeof data === 'string' ? 'json' : 'xml'
     let formRender = new FormRender(options)
-    let elems = this
-    elems.each(i => formRender.renderControl(elems[i]))
-    return elems
+    let $elems = this
+    $elems.each(i => formRender.renderControl($elems[i]))
+    return $elems
   }
 })(jQuery)

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -240,7 +240,7 @@ class FormRender {
 }
 
 ;(function($) {
-  $.fn.formRender = function(options) {    
+  $.fn.formRender = function(options) {
     let $elems = this
     let formRender = new FormRender(options)
     $elems.each(i => formRender.render($elems[i]))   


### PR DESCRIPTION
@kevinchappell  @wobh --I redid the commits to make it cleaner. Still learning git..

This is my attempt at bringing the formbuilder definition together with formrender plus the data that goes with the fields all together. An additional object called userData is added to the controls which can be saved in a database and pulled back for formrender to populate again. indexRender.html is a new demo page for testing this.

userData works for autocomplete, select, checkbox-group, radio-group, text, email, color, tel, number, hidden,date, textarea, textarea-tinymce.

For fields that have "other" option, a value that is not in the pre-defined values is assumed to be the "other" value.

I intend to use this by calling JSON.stringify(frInstance.userData) before posting to the database.

Other changes:

Adds a feature to respect the disabled attribute. Also made tinymce respect disabled attribute if set on the textarea.
Adds a feature to autocomplete which can optionally enforce only selecting the valid pre-defined options
Minor change to the getStarted text
Added h4 to paragraph