### PR TITLE
bootstrap grid/column support

### DIFF
--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -86,18 +86,14 @@ class FormRender {
         fields.forEach(field => {
           // Determine if rows are being used. If so, create the row and append to its row-{group}
           // If the fields have row-, create & append to the appropriate row
-          const classes = field.className.split('row-');
-          if(classes[1]){           
-            const rowGroup = classes[1].split(' ')[0];
+          const [ rowGroup ] = field.className.match(/row-([^\s]+)/)
+          if(rowGroup){           
             const rowID = this.id ? `${this.id}-row-${rowGroup}` : `row-${rowGroup}`;
 
             // Check if this rowID is created yet or not.            
             let rowGroupNode = document.getElementById(rowID);
-            if(!rowGroupNode){              
-              rowGroupNode = document.createElement('div');
-              rowGroupNode.id = rowID;
-              rowGroupNode.classList.add('row');   
-              rowGroupNode.classList.add('form-inline');
+            if(!rowGroupNode){ 
+              rowGroupNode = utils.markup('div', null, { id: rowID, className: 'row form-inline' });
               renderedFormWrap.appendChild(rowGroupNode)
             }
             rowGroupNode.appendChild(field);              

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -31,7 +31,7 @@ export default class layout {
     
         // Lift any col- and row- type class to the form-group wrapper. The row- class denotes the row group it should go to
         if(data.className){
-          const classes = data.className.split(' ').filter(className => (/^col-(xs|sm|md|lg)-\d+/.test(className) || className.startsWith('row-')));
+          const classes = data.className.split(' ').filter(className => (/^col-(xs|sm|md|lg)-([^\s]+)/.test(className) || className.startsWith('row-')));
           if(classes && classes.length > 0){
             className += ` ${classes.join(' ')}`;
 


### PR DESCRIPTION
There are a lot of requests for column support. Here is my implementation. I haven't tested with all form elements but the ones I needed worked fine.

This introduces the concept of columns using bootstrap grid system via class attributes set on the formBuilder elements. To set this up ....

1. add a row identifier onto the class i.e row-1
2. add the bootstrap grid columns i.e col-xs-6

All elements with the same row- identifier will be grouped into the same row
A second row can be added by repeating the same steps but setting a different row- identifier i.e row-2

![1](https://user-images.githubusercontent.com/5598169/48104437-7de7fb80-e201-11e8-9c44-3bca23d83006.JPG)
![2](https://user-images.githubusercontent.com/5598169/48104438-7de7fb80-e201-11e8-85ff-708f5bebc1dd.JPG)

