### PR TITLE
Changed function name

### DIFF
--- a/docs/formBuilder/options/onAddField.md
+++ b/docs/formBuilder/options/onAddField.md
@@ -15,7 +15,7 @@ Callback for when fields are added to the stage. Good as a catch-all action for 
 
 ```javascript
 const options = {
-  onFieldAdd: function(fieldId) {
+  onAddField: function(fieldId) {
     const currentFieldId = fieldId
   },
 }


### PR DESCRIPTION
The previous "onFieldAdd" option did not correctly call the function "onAddField". Update to function example to use correct call.