### PR TITLE
Fix markdown for list elements (docs display)

### DIFF
--- a/docs/formBuilder/overview.md
+++ b/docs/formBuilder/overview.md
@@ -1,6 +1,7 @@
 # Libraries and classes
 
 Key files / folders:
+
   * `control.js` - defines the parent class for all controls and a bunch of class level methods for defining information about each control (label, icon etc)
   * `control/*.js` - the individual controls to form the base set of controls transpiled into the final codebase, each inheriting from `control.js`.
   * `control_plugins/*.js` - additional controls which also inherit from `control.js` that remain outside the transpiled code but are able to be individually included as required. 


### PR DESCRIPTION
Fixes key files and folders list in the docs https://formbuilder.online/docs/formBuilder/overview/ ...
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/5728859/57033229-f7413380-6c11-11e9-9c7b-1bd53c4c2b49.png">

... to display as a list instead of a paragraph
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/5728859/57033178-d37ded80-6c11-11e9-9f62-f7e35a0ba96b.png">
