### PR TITLE
Added remaining heading tags to header control

### DIFF
--- a/src/js/control/paragraph.js
+++ b/src/js/control/paragraph.js
@@ -31,4 +31,4 @@ export default class controlParagraph extends control {
 // register the following controls
 control.register(['paragraph', 'header'], controlParagraph)
 control.register(['p', 'address', 'blockquote', 'canvas', 'output'], controlParagraph, 'paragraph')
-control.register(['h1', 'h2', 'h3', 'h4'], controlParagraph, 'header')
+control.register(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'], controlParagraph, 'header')


### PR DESCRIPTION
H5 and H6 were missing but are part of the heading elements.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements