### PR TITLE
Fixed "Invalid calling object" error caused by "console.log" in internet explorer.

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -41,9 +41,15 @@ export const defaultOptions = {
   fieldEditContainer: null, // DOM node or selector
   inputSets: [], // add groups of fields at a time
   notify: {
-    error: console.error,
-    success: console.log,
-    warning: console.warn,
+    error: error => {
+      console.log(error)
+    },
+    success: success => {
+      console.log(success)
+    },
+    warning: warning => {
+      console.warn(warning)
+    },
   },
   onAddField: (fieldId, fieldData) => fieldData,
   onClearAll: noop,

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -240,7 +240,7 @@ class FormRender {
     const fieldData = opts.formData
     if (!fieldData || Array.isArray(fieldData)) {
       throw new Error(
-        'To render a single element, please specify a single object of formData for the field in question',
+        'To render a single element, please specify a single object of formData for the field in question'
       )
     }
     const sanitizedField = this.santizeField(fieldData)
@@ -267,7 +267,7 @@ class FormRender {
       .filter(fieldData => fieldData.subtype === 'tinymce')
       .forEach(fieldData => window.tinymce.get(fieldData.name).save())
 
-    this.instanceContainers.forEach(container => {
+    this.instanceContainers.forEach((container) => {
       const userDataMap = $('select, input, textarea', container)
         .serializeArray()
         .reduce((acc, { name, value }) => {

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -38,9 +38,15 @@ class FormRender {
       render: true,
       templates: {}, // custom inline defined templates
       notify: {
-        error: console.error,
-        success: console.log,
-        warning: console.warn,
+        error: error => {
+          console.log(error)
+        },
+        success: success => {
+          console.log(success)
+        },
+        warning: warning => {
+          console.warn(warning)
+        },
       },
     }
     this.options = jQuery.extend(true, defaults, options)
@@ -234,7 +240,7 @@ class FormRender {
     const fieldData = opts.formData
     if (!fieldData || Array.isArray(fieldData)) {
       throw new Error(
-        'To render a single element, please specify a single object of formData for the field in question'
+        'To render a single element, please specify a single object of formData for the field in question',
       )
     }
     const sanitizedField = this.santizeField(fieldData)
@@ -261,7 +267,7 @@ class FormRender {
       .filter(fieldData => fieldData.subtype === 'tinymce')
       .forEach(fieldData => window.tinymce.get(fieldData.name).save())
 
-    this.instanceContainers.forEach((container) => {
+    this.instanceContainers.forEach(container => {
       const userDataMap = $('select, input, textarea', container)
         .serializeArray()
         .reduce((acc, { name, value }) => {


### PR DESCRIPTION
### Description:
formRender fails with error "Invalid calling object" in Internet Explorer 11. Due to this we get the return value as "undefined" from the "formRender" function. 

### Environment Details:

 - formBuilder Version: 3.3.1 (Used with ReactJS)
 - Browser: Internet Explorer 11
 - OS: Windows 10

### Steps to Reproduce
The issue is with the way console's functions are used in form-render.js and config.js.
![image](https://user-images.githubusercontent.com/8248042/73536092-2ed44a80-43f3-11ea-8fed-14f6bd1a8ed8.png)

This approach of assinging "console.log" / "console.warn" to a variable and invoking that variable as function does not work in internet explorer.

Below is sample code to reproduce. 
```HTML 
<!DOCTYPE html>
<html>
<head>
<title>Page Title</title>
</head>
<body>
<script>
alert(console.log);  // shows "native function"

var log = console.log;
alert(log);      // shows "native function"

console.log("You ain't gonna see me"); // silently ignored

log("I'm gonna crash!"); // result in an exception

alert("No exception");
</script> 
</body>
</html>
```

If we run the above code in internet explorer then the alert shows the native function". Notice that the alert message "No exception" isn't shown.

![image](https://user-images.githubusercontent.com/8248042/73536864-fafa2480-43f4-11ea-91e1-10e489430275.png)

If "Script debugging is enabled" then we can see the error "Invalid Calling Object"

![image](https://user-images.githubusercontent.com/8248042/73536800-cbe3b300-43f4-11ea-95c3-709af0d78e38.png)

If we open the "Developer Tools" and rerun this code than it works. Notice that the alert now shows a different function code block with a "try"/"catch" and also we can see alert message "No exception".

![image](https://user-images.githubusercontent.com/8248042/73538631-7a89f280-43f9-11ea-8505-b05cfc576c4e.png)

![image](https://user-images.githubusercontent.com/8248042/73538682-98efee00-43f9-11ea-833d-aba2a12e7dec.png)

Also before IE 10, the "console" object isn't available by default and only available if the developer tools are open. If someone needs support for older browser than IE 10 then a polyfill like below may need to be added.
```Javascript
if(!window.console) {
  var console = {
    log : function(){},
    warn : function(){},
    error : function(){},
  }
}
```
I am bit unsure, if changing this would have any impact. Please review and let me know your thoughts or suggestions or if any modifications are needed.
