### PR TITLE
Added 'type' for checkbox example

### DIFF
--- a/docs/formBuilder/options/typeUserAttrs.md
+++ b/docs/formBuilder/options/typeUserAttrs.md
@@ -30,6 +30,7 @@ const typeUserAttrs = {
     readonly: {
       label: 'readonly',
       value: false,
+      type: 'checkbox',
     }
   }
 };


### PR DESCRIPTION
Depending on the source data type (XML vs JSON) the custom field could be generated incorrectly. The checkbox example should show that you can force the type if needed.