### PR TITLE
Forcing Checkboxes for typeUserAttrs

### DIFF
--- a/docs/formBuilder/options/typeUserAttrs.md
+++ b/docs/formBuilder/options/typeUserAttrs.md
@@ -30,6 +30,7 @@ const typeUserAttrs = {
     readonly: {
       label: 'readonly',
       value: false,
+      type: 'checkbox',
     }
   }
 };

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -532,9 +532,11 @@ const FormBuilder = function(opts, element, $) {
       number: numberAttribute,
       boolean: (attr, attrData) => {
         let isChecked = false
-        if (values.hasOwnProperty(attr)) {
+        if(attr.type === 'checkbox'){
+          isChecked = Boolean(attrData.hasOwnProperty('value') ? attrData.value : false)
+        } else if (values.hasOwnProperty(attr)) {
           isChecked = values[attr]
-        } else if (attrData.hasOwnProperty('value') || attrData.hasOwnProperty('value')) {
+        } else if (attrData.hasOwnProperty('value') || attrData.hasOwnProperty('checked')) {
           isChecked = attrData.value || attrData.checked || false
         }
         return boolAttribute(attr, { ...attrData, [attr]: isChecked }, { first: attrData.label })


### PR DESCRIPTION
Useful for XML implementations of formBuilder. If a type of 'checkbox' is set for a custom attribute then only render/work with boolean values. 