### PR TITLE
Call onAddField callback after appending new field

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -232,8 +232,8 @@ const FormBuilder = function(opts, element, $) {
       setTimeout(() => document.dispatchEvent(events.fieldAdded), 10)
     }
 
-    opts.onAddField(data.lastID, field)
     appendNewField(field, isNew)
+    opts.onAddField(data.lastID, field)
 
     d.stage.classList.remove('empty')
   }


### PR DESCRIPTION
Proposed fix for onAddField callback is called before the lastID is incremented in appendNewField issue.

Closes #1096