### PR TITLE
Subtypes for Custom Controls

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -53,7 +53,9 @@ export default class Controls {
     if (customFields) {
       jQuery.merge(registeredControls, customFields)
     }
-
+    const registeredSubtypes = control.getRegisteredSubtypes()
+    this.registeredSubtypes = registeredSubtypes
+    
     // if we support rearranging control order, add classes to support this
     if (opts.sortableControls) {
       this.dom.classList.add('sort-enabled')

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -347,6 +347,10 @@ const FormBuilder = function(opts, element, $) {
       select: defaultAttrs.concat(['multiple', 'options']),
       textarea: defaultAttrs.concat(['subtype', 'maxlength', 'rows']),
     }
+    
+    if((type in controls.registeredSubtypes) && !(type in typeAttrsMap)){
+      typeAttrsMap[type] = defaultAttrs.concat(['subtype'])
+    }
 
     typeAttrsMap['checkbox-group'] = typeAttrsMap.checkbox
     typeAttrsMap['radio-group'] = typeAttrsMap.checkbox


### PR DESCRIPTION
Allows the 'type' field for custom controls. Fixes the issue in #894