### PR TITLE
Support the ability to define user attributes for subtype

### DIFF
--- a/src/demo/js/demo.js
+++ b/src/demo/js/demo.js
@@ -56,6 +56,16 @@ jQuery(function($) {
       },
       icon: '🌟',
     },
+    {
+      type: 'checkbox-group',
+      subtype: 'custom-group',
+      label: 'Custom Checkbox Group w/Sub Type',
+      required: true,
+      values: [
+        { label: 'Option 1' },
+        { label: 'Option 2' }
+      ]
+    }
   ]
 
   const replaceFields = [
@@ -187,10 +197,12 @@ jQuery(function($) {
       },
     },
     'checkbox-group': {
-      randomize: {
-        label: 'Randomize',
-        type: 'checkbox',
-        value: false,
+      'custom-group': {
+        customInput: {
+          label: 'Custom Text Field',
+          value: 'This field is added only to checkbox with specific subtype',
+          type: 'text'
+        }
       },
     },
   }
@@ -208,6 +220,7 @@ jQuery(function($) {
     dataType,
     subtypes: {
       text: ['datetime-local'],
+      'checkbox-group': ['custom-group']
     },
     onSave: toggleEdit,
     onAddField: fieldId => {

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -525,6 +525,16 @@ const FormBuilder = function(opts, element, $) {
   }
 
   /**
+   * 
+   * @param {Object} values    field attributes
+   * @param {String} subType   subType
+   * @return {Boolean}         indicates whether or not the field has a subtype
+   */
+  function hasSubType(values, subType) {
+    return values.subtype && values.subtype === subType
+  }
+
+  /**
    * Processes typeUserAttrs
    * @param  {Object} typeUserAttr option
    * @param  {Object} values       field attributes
@@ -552,21 +562,27 @@ const FormBuilder = function(opts, element, $) {
     for (const attribute in typeUserAttr) {
       if (typeUserAttr.hasOwnProperty(attribute)) {
         const attrValType = userAttrType(typeUserAttr[attribute])
-        const orig = mi18n.get(attribute)
-        const tUA = typeUserAttr[attribute]
-        const origValue = tUA.value || ''
-        tUA.value = values[attribute] || tUA.value || ''
+        if (attrValType !== 'undefined') {
+          const orig = mi18n.get(attribute)
+          const tUA = typeUserAttr[attribute]
+          const origValue = tUA.value || ''
+          tUA.value = values[attribute] || tUA.value || ''
 
-        if (tUA.label) {
-          i18n[attribute] = Array.isArray(tUA.label) ? mi18n.get(...tUA.label) || tUA.label[0] : tUA.label
+          if (tUA.label) {
+            i18n[attribute] = Array.isArray(tUA.label) ? mi18n.get(...tUA.label) || tUA.label[0] : tUA.label
+          }
+
+          if (attrTypeMap[attrValType]) {
+            advField.push(attrTypeMap[attrValType](attribute, tUA))
+          }
+
+          i18n[attribute] = orig
+          tUA.value = origValue
+        } else if (attrValType === 'undefined' && hasSubType(values, attribute)) {
+          advField.push(processTypeUserAttrs(typeUserAttr[attribute], values))
+        } else {
+          continue
         }
-
-        if (attrTypeMap[attrValType]) {
-          advField.push(attrTypeMap[attrValType](attribute, tUA))
-        }
-
-        i18n[attribute] = orig
-        tUA.value = origValue
       }
     }
 


### PR DESCRIPTION
This one tries to solve one part of #1046 (the ability to create user attributes based on subtypes)
Currently, only user attributes based on types are able to be added to the formBuilder instantiation process.

Please, review and let me know if it looks good or needs any adjustments.
(already working fine in my project)