### PR TITLE
feat/persistDefaultFields

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
     "node": true,
     "es6": true
   },
-  "extends": ["eslint:recommended"],
+  "extends": ["eslint:recommended", "prettier"],
+  "plugins": ["prettier"],
   "globals": {
     "jQuery": true,
     "$": true
@@ -28,7 +29,6 @@
         "destructuring": "any",
         "ignoreReadBeforeAssign": false
       }
-    ],
-    "space-before-function-paren": ["error", "never"]
+    ]
   }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "semi": false,
+  "arrowParens": "avoid",
+  "spaceAfterFunction": false
+}

--- a/docs/formBuilder/options/persistDefaultFields.md
+++ b/docs/formBuilder/options/persistDefaultFields.md
@@ -1,0 +1,25 @@
+# persistDefaultFields
+
+When `persistDefaultFields` is enabled, `defaultFields` defined in the formBuilder options will not be removed when clearing all fields.
+
+## Usage
+
+```javascript
+var options = {
+  defaultFields: [
+    {
+      className: 'form-control',
+      label: 'Default Field',
+      placeholder: 'Enter your default field value',
+      name: 'default-field-1',
+      type: 'text',
+    },
+  ],
+  persistDefaultFields: true,
+}
+$(container).formBuilder(options)
+```
+
+## See it in Action
+
+<p data-height="494" data-theme-id="22927" data-embed-version="2" data-slug-hash="WNpZZVg" data-default-tab="result" data-user="kevinchappell" class="codepen"></p>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
   - onCloseFieldEdit: formBuilder/options/onCloseFieldEdit.md
   - onOpenFieldEdit: formBuilder/options/onOpenFieldEdit.md
   - onSave: formBuilder/options/onSave.md
+  - persistDefaultFields: formBuilder/options/persistDefaultFields.md
   - replaceFields: formBuilder/options/replaceFields.md
   - roles: formBuilder/options/roles.md
   - scrollToFieldOnAdd: formBuilder/options/scrollToFieldOnAdd.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -5096,6 +5096,12 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true
+    },
     "eslint-loader": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-4.0.2.tgz",
@@ -5215,6 +5221,15 @@
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
+      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-scope": {
@@ -5593,6 +5608,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -12902,6 +12923,15 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-error": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,9 @@
     "cross-env": "^7.0.2",
     "css-loader": "^4.2.1",
     "eslint": "^7.7.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-loader": "^4.0.2",
+    "eslint-plugin-prettier": "^3.4.0",
     "formbuilder-languages": "latest",
     "fs-extra": "^9.0.1",
     "html-webpack-harddisk-plugin": "^1.0.2",
@@ -145,14 +147,6 @@
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",
     "wrapper-webpack-plugin": "^2.1.0"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "trailingComma": "all",
-    "printWidth": 120,
-    "semi": false,
-    "arrowParens": "avoid",
-    "spaceAfterFunction": false
   },
   "engines": {},
   "release": {

--- a/src/demo/js/demo.js
+++ b/src/demo/js/demo.js
@@ -31,7 +31,7 @@ const toggleBootStrap = ({ target }) => {
 
 document.getElementById('toggleBootstrap').addEventListener('click', toggleBootStrap, false)
 
-jQuery(function($) {
+jQuery(function ($) {
   const fields = [
     {
       type: 'autocomplete',
@@ -61,11 +61,8 @@ jQuery(function($) {
       subtype: 'custom-group',
       label: 'Custom Checkbox Group w/Sub Type',
       required: true,
-      values: [
-        { label: 'Option 1' },
-        { label: 'Option 2' }
-      ]
-    }
+      values: [{ label: 'Option 1' }, { label: 'Option 2' }],
+    },
   ]
 
   const replaceFields = [
@@ -95,7 +92,7 @@ jQuery(function($) {
   ]
 
   const templates = {
-    starRating: function(fieldData) {
+    starRating: function (fieldData) {
       return {
         field: '<span id="' + fieldData.name + '">',
         onRender: () => {
@@ -201,8 +198,8 @@ jQuery(function($) {
         customInput: {
           label: 'Custom Text Field',
           value: 'This field is added only to checkbox with specific subtype',
-          type: 'text'
-        }
+          type: 'text',
+        },
       },
     },
   }
@@ -211,6 +208,16 @@ jQuery(function($) {
   const disabledAttrs = ['placeholder', 'name']
 
   const fbOptions = {
+    defaultFields: [
+      {
+        className: 'form-control',
+        label: 'Default Field',
+        placeholder: 'Enter your default field value',
+        name: 'default-field-1',
+        type: 'text',
+      },
+    ],
+    persistDefaultFields: true,
     disabledSubtypes: {
       text: ['password'],
     },
@@ -220,13 +227,13 @@ jQuery(function($) {
     dataType,
     subtypes: {
       text: ['datetime-local'],
-      'checkbox-group': ['custom-group']
+      'checkbox-group': ['custom-group'],
     },
     onSave: toggleEdit,
     onAddField: fieldId => {
       setCurrentFieldIdValues(fieldId)
     },
-    onAddOption: (optionTemplate, {index}) => {
+    onAddOption: (optionTemplate, { index }) => {
       optionTemplate.label = optionTemplate.label || `Option ${index + 1}`
       optionTemplate.value = optionTemplate.value || `option-${index + 1}`
 
@@ -290,7 +297,7 @@ jQuery(function($) {
 
   const fbPromise = formBuilder.promise
 
-  fbPromise.then(function(fb) {
+  fbPromise.then(function (fb) {
     document.querySelectorAll('.editForm').forEach(element => element.addEventListener('click', toggleEdit), false)
     const langSelect = document.getElementById('setLanguage')
     const savedLocale = window.sessionStorage.getItem(localeSessionKey) || defaultLocale

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -62,6 +62,7 @@ export const defaultOptions = {
    * @param {Object} formData
    */
   onSave: noop,
+  persistDefaultFields: false,
   prepend: false,
   replaceFields: [],
   roles: {

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -180,7 +180,7 @@ const FormBuilder = function(opts, element, $) {
   }
 
   // builds the standard formbuilder datastructure for a field definition
-  const prepFieldVars = function($field, isNew = false) {
+  const prepFieldVars = ($field, isNew = false) => {
     let field = {}
     if ($field instanceof jQuery) {
       // get the default type etc & label for this field
@@ -244,6 +244,8 @@ const FormBuilder = function(opts, element, $) {
     d.stage.classList.remove('empty')
   }
 
+  formBuilder.prepFieldVars = prepFieldVars
+
   // Parse saved XML template data
   const loadFields = function(formData) {
     formData = h.getData(formData)
@@ -251,9 +253,7 @@ const FormBuilder = function(opts, element, $) {
       formData.forEach(fieldData => prepFieldVars(trimObj(fieldData)))
       d.stage.classList.remove('empty')
     } else if (opts.defaultFields && opts.defaultFields.length) {
-      // Load default fields if none are set
-      opts.defaultFields.forEach(field => prepFieldVars(field))
-      d.stage.classList.remove('empty')
+      h.addDefaultFields()
     } else if (!opts.prepend && !opts.append) {
       d.stage.classList.add('empty')
       d.stage.dataset.content = mi18n.get('getStarted')
@@ -526,7 +526,7 @@ const FormBuilder = function(opts, element, $) {
   }
 
   /**
-   * 
+   *
    * @param {Object} values    field attributes
    * @param {String} subType   subType
    * @return {Boolean}         indicates whether or not the field has a subtype

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -658,7 +658,6 @@ export default class Helpers {
   }
 
   addDefaultFields() {
-    console.log('defaults added back')
     // Load default fields if none are set
     config.opts.defaultFields.forEach(field => this.formBuilder.prepFieldVars(field))
     this.d.stage.classList.remove('empty')

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -194,7 +194,7 @@ export default class Helpers {
 
     if (form.childNodes.length !== 0) {
       // build data object
-      forEach(form.childNodes, function(index, field) {
+      forEach(form.childNodes, function (index, field) {
         const $field = $(field)
 
         if (!$field.hasClass('disabled-field')) {
@@ -358,13 +358,13 @@ export default class Helpers {
 
     const fieldType = $field.attr('type')
     const $prevHolder = $('.prev-holder', field)
-    let previewData = Object.assign({}, _this.getAttrVals(field, previewData), { type: fieldType })
+    let previewData = Object.assign({}, _this.getAttrVals(field), { type: fieldType })
 
     if (fieldType.match(d.optionFieldsRegEx)) {
       previewData.values = []
       previewData.multiple = $('[name="multiple"]', field).is(':checked')
 
-      $('.sortable-options li', field).each(function(i, $option) {
+      $('.sortable-options li', field).each(function (i, $option) {
         const option = {
           selected: $('.option-selected', $option).is(':checked'),
           value: $('.option-value', $option).val(),
@@ -453,9 +453,7 @@ export default class Helpers {
       classes.push(primaryType)
     }
 
-    const trimmedClassName = unique(classes)
-      .join(' ')
-      .trim()
+    const trimmedClassName = unique(classes).join(' ').trim()
 
     className.value = trimmedClassName
 
@@ -553,11 +551,11 @@ export default class Helpers {
       className: 'no btn btn-danger btn-sm',
     })
 
-    no.onclick = function() {
+    no.onclick = function () {
       _this.closeConfirm(overlay)
     }
 
-    yes.onclick = function() {
+    yes.onclick = function () {
       yesAction()
       _this.closeConfirm(overlay)
     }
@@ -659,6 +657,13 @@ export default class Helpers {
     }
   }
 
+  addDefaultFields() {
+    console.log('defaults added back')
+    // Load default fields if none are set
+    config.opts.defaultFields.forEach(field => this.formBuilder.prepFieldVars(field))
+    this.d.stage.classList.remove('empty')
+  }
+
   /**
    * Removes all fields from the form
    * @param {Object} stage to remove fields form
@@ -683,7 +688,7 @@ export default class Helpers {
       markEmptyArray.push(true)
     }
 
-    if (!markEmptyArray.some(elem => elem === true)) {
+    if (!markEmptyArray.some(Boolean)) {
       stage.classList.add('empty')
       stage.dataset.content = i18n.getStarted
     }
@@ -693,14 +698,20 @@ export default class Helpers {
       let outerHeight = 0
       forEach(fields, index => (outerHeight += fields[index].offsetHeight + 3))
       fields[0].style.marginTop = `${-outerHeight}px`
-      const animateTimeout = setTimeout(() => {
-        empty(stage).classList.remove('removing')
-        this.save()
-        clearTimeout(animateTimeout)
-      }, 400)
-    } else {
-      empty(stage)
-      this.save()
+    }
+
+    const animationTimeout = animate ? 400 : 0
+    const animateTimeout = setTimeout(() => {
+      this.emptyStage(stage)
+      clearTimeout(animateTimeout)
+    }, animationTimeout)
+  }
+
+  emptyStage(stage) {
+    empty(stage).classList.remove('removing')
+    this.save()
+    if (config.opts.persistDefaultFields) {
+      this.addDefaultFields()
     }
   }
 
@@ -806,7 +817,7 @@ export default class Helpers {
     const cbPosition = controls.getBoundingClientRect()
     const { top: stageTop } = stage.getBoundingClientRect()
 
-    $(window).scroll(function(evt) {
+    $(window).scroll(function (evt) {
       const scrollTop = $(evt.target).scrollTop()
       const offsetDefaults = {
         top: 5,
@@ -901,7 +912,7 @@ export default class Helpers {
       return false
     }
 
-    $field.slideUp(animationSpeed, function() {
+    $field.slideUp(animationSpeed, function () {
       $field.removeClass('deleting')
       $field.remove()
       fieldRemoved = true


### PR DESCRIPTION
- fix package.json name
- fix typo
- typeUserAttrs bugfix (#851)
- v2.10.1
- Fix i18n Issues (#852)
- Cusotm controls marked loaded before they are loaded for formRender (#853)
- Add demo to userData docs
- fix(docs): Add missing documentation (#855)
- fix(ci): deploys
- Fix: typo in deploy script
- fix(ci): deploy
- fix(ci): deploy script typo
- fix(cd): update encrypted access keys
- fix(package.json): update repository.url
- fix(cd): semantic-release plugins, site deploy commands
- chore(release): 2.10.5 [skip ci]
- fix(cd): update readme, have deploy script return, run deploy script directly
- fix(cd): update deploy script to not require babel-node
- update build script
- chore(release): 2.10.6 [skip ci]
- fix(cd): update travis config and deploy script
- fix(formData): formData getter not working
- chore(release): 2.10.7 [skip ci]
- add npm script deploy:site
- remove gitsubmodule
- fix(cd): website auto deploy
- chore(release): 2.10.8 [skip ci]
- Update website submodule
- fix(docs): use highlightjs 9.12.0
- chore(release): 2.10.9 [skip ci]
- fix(labels): html in xml labels breaks forms (#858)
- chore(release): 3.0.0 [skip ci]
- chore(demo): Remove demo (#861)
- Remove site submodule (#863)
- fix(plugins): fix plugins build script
- chore(release): 3.0.1 [skip ci]
- fix(package.json): remove preinstall (#865)
- chore(release): 3.0.2 [skip ci]
- feat(column): add bootstrap grid/column support
- chore(release): 3.1.0 [skip ci]
- chore(demo): Add Bootstrap Grid Support Demo
- fix(formRender): error when destrtcuring null
- chore(release): 3.1.1 [skip ci]
- fix(xml): fields are nesting
- chore(release): 3.1.2 [skip ci]
- fix(langs): Update formBuilder-languages dependency
- fix(dependency): har-validator 5.1.2 was unpublished, causing ci builds to fail. Update dependencies to fix
- chore(release): 3.1.3 [skip ci]
- feat(i18n): add support for translatable typeUserAttrs
- chore(release): 3.2.0 [skip ci]
- fix(btn): button style classes not correctly applied
- chore(release): 3.2.1 [skip ci]
- chore: update docs to include disableable controls
- define new methods object for every new formBuilder instance
- Update development.md
- Changed function name
- fix: update jquery dependency
- chore: update dependency versions
- chore(release): 3.2.2 [skip ci]
- Fix markdown for list elements
- chore: switch back to npm
- fix: development build, upgrade babel
- fix: use run-script instead of run
- update package-lock
- chore(release): 3.2.3 [skip ci]
- fix: numeric value preservation
- fix: npm audit
- chore(release): 3.2.4 [skip ci]
- Update controls.md
- Allow the textarea.quill control to be configured by passing in options in the controlConfig object
- fix: browserslist config, build:vendor
- update package-lock.json
- chore(release): 3.2.5 [skip ci]
- Added remaining heading tags to header control
- fix one char typo
- fixed(editor): bug in numberAttribute method where min, max and step where passed on as attributes instead of as value (#1018)
- chore(deps): bump mixin-deep from 1.3.1 to 1.3.2
- chore(deps): bump eslint-utils from 1.3.1 to 1.4.3
- chore(deps): bump lodash from 4.17.11 to 4.17.15
- chore(deps): bump npm from 6.9.0 to 6.13.4
- chore(deps): bump handlebars from 4.1.2 to 4.5.3
- chore(ci): update travis yaml
- update deps
- fix: adblock because of fb- prefix
- update icons location
- rename files
- chore(release): 3.2.6 [skip ci]
- feat: getCurrentFieldId
- refactor syntax
- fix(demo): clear current id when removed from stage
- update controlTrumbowyg formatting
- move titleCase to utils
- update travis python
- travis python
- manually install and link python
- move original python3 first
- chore(release): 3.3.0 [skip ci]
- update readme
- update demo deployment commands
- fix: field removed from stage but not formData
- chore(release): 3.3.1 [skip ci]
- change ssh to https for demo deploy
- fixed(ie11): "Invalid calling object" error caused by "console.log" in internet explorer. (#1033)
- fix: build
- chore(release): 3.3.2 [skip ci]
- fix: travis deploy
- fix: travis node version, include docs in dist package
- chore(release): 3.3.3 [skip ci]
- fix: update dependencies
- wrap in a try catch
- chore(release): 3.3.4 [skip ci]
- fix: website generation and deployment
- chore(release): 3.3.5 [skip ci]
- feat(editor): hidden field labels
- chore(release): 3.4.0 [skip ci]
- update deploy-site
- use ghpages action
- fix build_dir
- update deploy action
- use build:all for the demo
- correct demo BUILD_DIR
- fix: multiple attribute added to select
- chore(release): 3.4.1 [skip ci]
- resolves #1022
- Added userData to XML formData
- fix: clone id bug
- chore(release): 3.4.2 [skip ci]
- Update example onSave to have correct arguments
- chore(deps): bump acorn from 6.4.0 to 6.4.1
- Add src to distribution, fixes #1069
- chore(deps): bump jquery from 3.4.1 to 3.5.0
- Fix typo
- Added 'type' for checkbox example
- Condition for checkbox type
- chore(deps): bump websocket-extensions from 0.1.3 to 0.1.4
- Call onAddField callback after appending new field
- chore(deps): bump lodash from 4.17.15 to 4.17.19
- chore(deps): bump elliptic from 6.5.2 to 6.5.3
- Subtypes for Custom Controls
- Added disableInjectedStyle
- chore(deps): bump npm from 6.13.7 to 6.14.8
- fix: copy language files from module
- chore(release): 3.4.3 [skip ci]
- fix: checkbox other value
- fix: timeout memory leaks
- chore(release): 3.4.4 [skip ci]
- fix: onSave not called when save called from the api
- chore(release): 3.4.5 [skip ci]
- feat: onAddOption
- add doc
- chore(release): 3.5.0 [skip ci]
- fix: site home url in /docs
- chore(release): 3.5.1 [skip ci]
- fix: icon name conflict
- remove travis-deploy-once
- remove mini-css-extract-plugin
- remove commented out code
- update formatting
- chore(release): 3.5.2 [skip ci]
- feat: custom option attributes
- chore(release): 3.6.0 [skip ci]
- fix: onAddOption default
- uncomment demo onAddOption
- chore(release): 3.6.1 [skip ci]
- fix: radio group option remove button visible on second option
- chore(release): 3.6.2 [skip ci]
- chore: update docs
- fix font edit not working with http
- #1131 fixes the regression to the onAddField callback. implements a new form builder option and callback onAddFieldAfter that runs after the form has been appended to the stage
- chore(deps): bump node-fetch from 2.6.0 to 2.6.1
- chore(deps-dev): bump semantic-release from 17.1.1 to 17.2.3
- chore(deps): bump ini from 1.3.5 to 1.3.7
- chore(deps): bump elliptic from 6.5.3 to 6.5.4
- add support for defining subtype user attributes
- add demo with subtype user attr
- chore(deps): bump y18n from 4.0.0 to 4.0.1
- chore(deps): bump ssri from 6.0.1 to 6.0.2
- chore(deps): bump url-parse from 1.4.7 to 1.5.1
- chore(deps): bump lodash from 4.17.20 to 4.17.21
- chore(deps): bump handlebars from 4.7.6 to 4.7.7
- chore(deps): bump hosted-git-info from 2.8.8 to 2.8.9
- chore(deps): bump browserslist from 4.14.0 to 4.16.6
- chore(deps): bump dns-packet from 1.3.1 to 1.3.4
- feat: persistDefaultFields option
- refactor: add missing files
