### PR TITLE
Add a per epoch counter to generate unique names

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -162,11 +162,21 @@ export const bindEvents = (element, events) => {
  * @param  {Object} field
  * @return {String}       name
  */
-export const nameAttr = function(field) {
-  const epoch = new Date().getTime()
-  const prefix = field.type || hyphenCase(field.label)
-  return prefix + '-' + epoch
-}
+export const nameAttr = (function() {
+  let lepoch
+  let counter = 0
+  return function(field) {
+    const epoch = new Date().getTime()
+    if (epoch === lepoch) {
+      ++counter
+    } else {
+      counter = 0
+      lepoch = epoch
+    }
+    const prefix = field.type || hyphenCase(field.label)
+    return prefix + '-' + epoch + '-' + counter
+  }
+})()
 
 /**
  * Determine content type


### PR DESCRIPTION
Fixes #1198 this is a proposed fix to ensure unique names are generated names for identical field types at the same epoch. A per epoch counter is implemented.

Changes: New elements now have a default value of prefix-epoch-counter starting from 0

I also investigated using performance.now(), however on Safari and Firefox the resolution for performance.now() is no greater than Date().getTime().