### PR TITLE
Ensure boolean attributes are set only when true and to a valid value

### DIFF
--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -197,7 +197,7 @@ export default class controlSelect extends control {
 
           for (let i = 0; i < selectedOptions.length; i++) {
             if (input.value === selectedOptions[i]) {
-              input.setAttribute('checked', true)
+              input.setAttribute('checked', 'checked')
               selectedOptions.splice(i, 1) // Remove this item from the list
               break
             }
@@ -212,7 +212,7 @@ export default class controlSelect extends control {
             }
 
             // set the other value
-            input.setAttribute('checked', true)
+            input.setAttribute('checked', 'checked')
             otherVal.value = input.value = selectedOptions[0]
             // show other value
             otherVal.style.display = 'inline-block'

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -238,7 +238,13 @@ export const markup = function(tag, content = '', attributes = {}) {
     if (attrs.hasOwnProperty(attr)) {
       const name = safeAttrName(attr)
       const attrVal = Array.isArray(attrs[attr]) ? unique(attrs[attr].join(' ').split(' ')).join(' ') : attrs[attr]
-      field.setAttribute(name, attrVal)
+      if (typeof attrVal === 'boolean') {
+        if (attrVal === true) {
+          field.setAttribute(name, name)
+        }
+      } else {
+        field.setAttribute(name, attrVal)
+      }
     }
   }
 


### PR DESCRIPTION
Currently, in utils.js and select.js boolean attributes are set to "true" and "false" which are not valid under the HTML5 specification https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#boolean_attributes / https://www.w3.org/TR/html52/infrastructure.html#sec-boolean-attributes

Per the specification "If the attribute is present, its value must either be the empty string or a value that is an ASCII case-insensitive match for the attribute’s canonical name, with no leading or trailing white space."

Fixes #1209, #1152