### PR TITLE
Remove type="textarea" from textarea elements to match HTML5 spec

### DIFF
--- a/src/js/control/textarea.js
+++ b/src/js/control/textarea.js
@@ -23,6 +23,8 @@ export default class controlTextarea extends control {
    */
   build() {
     const { value = '', ...attrs } = this.config
+    //Textareas do not have an attribute 'type'
+    delete attrs['type']
     this.field = this.markup('textarea', this.parsedHtml(value), attrs)
     return this.field
   }

--- a/src/js/control/textarea.quill.js
+++ b/src/js/control/textarea.quill.js
@@ -45,6 +45,8 @@ export default class controlQuill extends controlTextarea {
   build() {
     // eslint-disable-next-line no-unused-vars
     const { value = '', ...attrs } = this.config
+    //Textareas do not have an attribute 'type'
+    delete attrs['type']
     this.field = this.markup('div', null, attrs)
     return this.field
   }

--- a/src/js/control/textarea.tinymce.js
+++ b/src/js/control/textarea.tinymce.js
@@ -58,6 +58,8 @@ export default class controlTinymce extends controlTextarea {
    */
   build() {
     const { value = '', ...attrs } = this.config
+    //Textareas do not have an attribute 'type'
+    delete attrs['type']
     this.field = this.markup('textarea', this.parsedHtml(value), attrs)
     // Make the editor read only if disabled is set on the textarea
     if (attrs.disabled) {


### PR DESCRIPTION
Text areas rendered by FormBuilder fail the W3C https://validator.w3.org/ due to element containing the attribute 'type' set to 'textarea'. This patch drops the type attribute in the control's build() step before passing the data to utils.markup for rendering