### PR TITLE
Fix rendering of required checkbox-groups with userData

### DIFF
--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -33,7 +33,12 @@ export default class controlSelect extends control {
     }
 
     if (type === 'checkbox-group' && data.required) {
-      this.onRender = this.groupRequired
+      const self = this
+      const defaultOnRender = this.onRender.bind(this)
+      this.onRender = function() {
+        self.groupRequired()
+        defaultOnRender()
+      }
     }
 
     delete data.title


### PR DESCRIPTION
Override of onRender breaks checkbox-groups which have the required flag set along with provided userData. Ensure we call both the groupRequired function along with the original onRender.

Fixes #1218