### PR TITLE
Ensure groupRequire events run after applying any user data to checkbox groups

### DIFF
--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -36,8 +36,8 @@ export default class controlSelect extends control {
       const self = this
       const defaultOnRender = this.onRender.bind(this)
       this.onRender = function() {
-        self.groupRequired()
         defaultOnRender()
+        self.groupRequired()
       }
     }
 


### PR DESCRIPTION
groupRequired events should be attached after rendering the element. This is due to the fact that no change event is triggered after any checkboxes are checked via the onRender user data code.

Resolves #1259