### PR TITLE
Revert change to FormBuilder.getFormData which triggers the stage to close on call

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1265,8 +1265,6 @@ export default class Helpers {
    * @return {Array|String} formData
    */
   getFormData(type = 'js', formatted = false) {
-    this.closeAllEdit()
-
     const h = this
     const data = {
       js: () => h.prepData(h.d.stage),


### PR DESCRIPTION
Fixes https://github.com/kevinchappell/formBuilder/issues/1295

Version 3.8.0 added a closeAllEdit() call to getFormData() which causes the stage to close. getFormData should not cause any side effects on call, it should only return the formData