### PR TITLE
Fix CSP violation by removing node.js global polyfill from webpack generated files

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -38,6 +38,9 @@ const bannerTemplate = ({ chunk }) => {
 }
 
 const webpackConfig = {
+  node: {
+    global: false,
+  },
   context: outputDir,
   entry: {
     'dist/form-builder': resolve(__dirname, '../', pkg.config.files.formBuilder.js),


### PR DESCRIPTION
Fixes #1300 

The [node.js global polyfill](https://github.com/webpack/webpack/blob/webpack-4/buildin/global.js)  included by webpack uses the unsafe new Function(<string>) triggering a Content Security Policy violation 'Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script' on secure installations that don't allow unsave-eval

This PR is the bare minimum removing the global polyfill. With some simple testing it does appear that all node polyfills can be excluded (node: false) however I'll leave that up to @kevinchappell to decide