### PR TITLE
Online demo fix for loading formBuilder when window.SessionStorage is unavailable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14528,6 +14528,12 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
+    "storage-available": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/storage-available/-/storage-available-1.1.0.tgz",
+      "integrity": "sha512-uFHjhmUxyxjEhoEl2sB+ogNWpPoFihk59cfSzPs0wXcCVRtpRti7u3G0O3VEyUuJJIg0oj0g7VGldsNSuhOoqQ==",
+      "dev": true
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "sass-loader": "^9.0.3",
     "semantic-release": "^17.1.1",
     "semver": "^7.3.2",
+    "storage-available": "^1.1.0",
     "style-loader": "^1.2.1",
     "unzipper": "^0.10.11",
     "webpack": "^4.44.1",

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -4,6 +4,7 @@ import controlCustom from './control/custom'
 import { unique, hyphenCase, markup as m } from './utils'
 import { empty } from './dom'
 import { css_prefix_text } from '../fonts/config.json'
+import storageAvailable from 'storage-available'
 
 /**
  * control parent class for creating control panel
@@ -129,7 +130,7 @@ export default class Controls {
     let fieldOrder
 
     // retrieve any saved ordering from the session
-    if (window.sessionStorage) {
+    if (storageAvailable('sessionStorage')) {
       if (opts.sortableControls) {
         fieldOrder = window.sessionStorage.getItem('fieldOrder')
       } else {

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -21,6 +21,7 @@ import events from './events'
 import { config, defaultTimeout } from './config'
 import control from './control'
 import controlCustom from './control/custom'
+import storageAvailable from 'storage-available'
 
 /**
  * Utilities specific to form-builder.js
@@ -752,7 +753,7 @@ export default class Helpers {
     if (!config.opts.sortableControls) {
       return false
     }
-    const { sessionStorage, JSON } = window
+    const JSON = window.JSON
 
     const fieldOrder = []
 
@@ -763,8 +764,8 @@ export default class Helpers {
       }
     })
 
-    if (sessionStorage) {
-      sessionStorage.setItem('fieldOrder', JSON.stringify(fieldOrder))
+    if (storageAvailable('sessionStorage')) {
+      window.sessionStorage.setItem('fieldOrder', JSON.stringify(fieldOrder))
     }
     return fieldOrder
   }


### PR DESCRIPTION
formBuilder uses window.sessionStorage directly with no error handling when storage is unavailable. This is seen when loading the https://formbuilder.online/ demos in Chrome, preventing them from rendering

> Uncaught (in promise) DOMException: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.
>     at v.orderFields (https://formbuilder.online/assets/js/form-builder.min.js:19:105681)
>     at v.appendControls (https://formbuilder.online/assets/js/form-builder.min.js:19:106250)
>     at v.init (https://formbuilder.online/assets/js/form-builder.min.js:19:104435)
>     at new v (https://formbuilder.online/assets/js/form-builder.min.js:19:104395)
>     at new I (https://formbuilder.online/assets/js/form-builder.min.js:19:108218)
>     at HTMLDivElement.<anonymous> (https://formbuilder.online/assets/js/form-builder.min.js:19:142653)
>     at Function.each (https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js:2:2882)
>     at n.fn.init.each (https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js:2:847)
>     at https://formbuilder.online/assets/js/form-builder.min.js:19:142636

Use npm package storage-available to ensure we can read/write to window.SessionStorage before we access it, preventing uncaught Exception DOMException: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document

Fixes #1135