### PR TITLE
Fix Uncaught TypeError when using "other" option in radio and checkbox-group

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1704,6 +1704,7 @@ function FormBuilder(opts, element, $) {
       } else {
         prevOptions = document.getElementsByName(e.target.name)
         forEach(prevOptions, i => {
+          if (prevOptions[i].classList.contains('other-option')) return //Cannot set other as a default checked
           const selectedOption = options[i].parentElement.childNodes[0]
           selectedOption.checked = prevOptions[i].checked
         })


### PR DESCRIPTION
There is no checkbox setting for marking "other" as default selected skip it when synchronising the selected options.

Fixes #1320 