### PR TITLE
Fix incorrect re-assignment of Other input's name attribute

### DIFF
--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -124,7 +124,6 @@ export default class controlSelect extends control {
               const otherInput = evt.target
               const other = otherInput.parentElement.previousElementSibling
               other.value = otherInput.value
-              other.name = `${data.id}[]`
             },
           },
           id: `${otherOptionAttrs.id}-value`,


### PR DESCRIPTION
The input handler for entry into the Other text input field would override the primary input name with a multiple [] appended name. This breaks radio-groups because the other now has a different name and therefore you can select the other option along with any provided option.

I cannot see where this name change would be required. The primaryInput field (radio or checkbox) gets its name from data.name which is the correct value for checkbox-group and radio-group. Select and multi-select do not support other option. 

https://github.com/kevinchappell/formBuilder/blob/013d0f91bb281a01bfdf9a774621d764fd489b78/src/js/control/select.js#L117

The only place I haven't tested is the singular checkbox control, however that is a disabled control per select.js https://github.com/kevinchappell/formBuilder/blob/013d0f91bb281a01bfdf9a774621d764fd489b78/src/js/control/select.js#L15

Fixes #1318
Fixes #1172

@kevinchappell  This appeared to be changed a few times in #1061, #483, #485 to fix radio, then checkbox however after reverting https://github.com/kevinchappell/formBuilder/commit/7e7569ef770d2adc568b1663c5a5ebb4095cf2c9 both checkbox-group and radio-group are working correctly for me (tested Firefox and Chrome)