### PR TITLE
Incorrect class list generated for other- option if class is not set

### DIFF
--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -105,7 +105,7 @@ export default class controlSelect extends control {
       if (!isSelect && other) {
         const otherOptionAttrs = {
           id: `${data.id}-other`,
-          className: `${data.className} other-option`,
+          className: `${data.className ?? ''} other-option`,
           value: '',
         }
 


### PR DESCRIPTION
Small fix. If not className is assigned to the control then the class attribute for the other option becomes "undefined other-option", null coalesce to an empty string.