### PR TITLE
Fix input touchstart event handling

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1639,7 +1639,7 @@ function FormBuilder(opts, element, $) {
 
   // touch focus
   $stage.on('touchstart', 'input', e => {
-    const $input = $(this)
+    const $input = $(e.target)
     if (e.handled !== true) {
       if ($input.attr('type') === 'checkbox') {
         $input.trigger('click')


### PR DESCRIPTION
The input element is contained in e.target, 'this' refers to $stage in the callback