### PR TITLE
Fix numberAttributes with a valid value of 0

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -882,7 +882,7 @@ function FormBuilder(opts, element, $) {
    */
   const numberAttribute = (attribute, values) => {
     const { class: classname, className, value, ...attrs } = values
-    const attrVal = attrs[attribute] || value
+    const attrVal = (isNaN(attrs[attribute])) ? value : attrs[attribute]
     const attrLabel = mi18n.get(attribute) || attribute
     const placeholder = mi18n.get(`placeholder.${attribute}`)
 


### PR DESCRIPTION
A number attribute's value may be any Number including zero, cannot check existence of the value using ||, instead check if the value is NaN

Fixes #1337 