### PR TITLE
Add nullish coalescing plugin to babel configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "comments": false,
     "plugins": [
       "@babel/plugin-proposal-object-rest-spread",
-      "@babel/plugin-proposal-class-properties"
+      "@babel/plugin-proposal-class-properties",
+      "@babel/plugin-proposal-nullish-coalescing-operator"
     ]
   },
   "scripts": {
@@ -108,6 +109,7 @@
     "@babel/core": "^7.11.4",
     "@babel/node": "^7.10.5",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
     "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
     "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
     "@babel/plugin-transform-destructuring": "^7.10.4",


### PR DESCRIPTION
After pulling a fresh copy of FormBuilder I was getting a babel issue with the nullish coalescing operator introduced in https://github.com/kevinchappell/formBuilder/pull/1332, seems safe to add it into Babel's config (even though CI built the plugin fine)