### PR TITLE
Calculate key before src variable is overwritten

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -495,8 +495,8 @@ export const getStyles = (scriptScr, path) => {
     if (typeof src == 'object') {
       type = src.type || (src.style ? 'inline' : 'href')
       id = src.id
-      src = type == 'inline' ? src.style : src.href
       key = id || src.href || src.style
+      src = type == 'inline' ? src.style : src.href
     }
 
     // check we haven't already loaded this css


### PR DESCRIPTION
src was overwritten and make a string in the line prior to calculating the key. 

If no id is set in src.id then the key is calculated incorrectly as undefined