### PR TITLE
Use the created element when setting userData value

### DIFF
--- a/src/js/control/hidden.js
+++ b/src/js/control/hidden.js
@@ -10,8 +10,9 @@ export default class controlHidden extends control {
    * @return {Object} DOM Element to be injected into the form.
    */
   build() {
+    this.field = this.markup('input', null, this.config)
     return {
-      field: this.markup('input', null, this.config),
+      field: this.field,
       layout: 'hidden',
     }
   }
@@ -22,7 +23,7 @@ export default class controlHidden extends control {
   onRender() {
     // Set userData if available
     if (this.config.userData) {
-      $('#' + this.config.name).val(this.config.userData[0])
+      $(this.field).val(this.config.userData[0])
     }
   }
 }

--- a/src/js/control/textarea.js
+++ b/src/js/control/textarea.js
@@ -35,7 +35,7 @@ export default class controlTextarea extends control {
   onRender() {
     // Set userData if available
     if (this.config.userData) {
-      $('#' + this.config.name).val(this.config.userData[0])
+      $(this.field).val(this.config.userData[0])
     }
   }
 


### PR DESCRIPTION
The form container element may not be included in the DOM when we render the form. If this is the case then the textarea and hidden element will not be found by the jQuery selector and no user value will be set. Change brings these two controls into the same onRender functionality of other controls like text.js