### PR TITLE
Fix translation of "Other" label in rendered radio/checkbox group

### DIFF
--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -130,7 +130,7 @@ export default class controlSelect extends control {
           className: 'other-val',
         }
         const primaryInput = this.markup('input', null, optionAttrs)
-        const otherInputs = [document.createTextNode('Other'), this.markup('input', null, otherValAttrs)]
+        const otherInputs = [document.createTextNode(control.mi18n('other')), this.markup('input', null, otherValAttrs)]
         const inputLabel = this.markup('label', otherInputs, { for: optionAttrs.id })
         const wrapper = this.markup('div', [primaryInput, inputLabel], { className: wrapperClass })
         options.push(wrapper)


### PR DESCRIPTION
The "Other" option string is hard-coded to English.  Use the value from the language file.

Fixes #1163
Fixes #1228