### PR TITLE
Use the i18n translated label for boolean typeUserAttrs. 

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -686,7 +686,7 @@ function FormBuilder(opts, element, $) {
         } else if (attrData.hasOwnProperty('value') || attrData.hasOwnProperty('checked')) {
           isChecked = attrData.value || attrData.checked || false
         }
-        return boolAttribute(attr, { ...attrData, [attr]: isChecked }, { first: attrData.label })
+        return boolAttribute(attr, { ...attrData, [attr]: isChecked }, { first: i18n[attr] })
       },
     }
 


### PR DESCRIPTION
Boolean userTypeAttrs were using the label directly instead of using the translated value

Fixes #1391