### PR TITLE
Force browsers to use <br> instead of <div> for newlines in contenteditable fields

### DIFF
--- a/src/sass/_stage.scss
+++ b/src/sass/_stage.scss
@@ -543,6 +543,10 @@
       height: auto;
     }
 
+    [contenteditable].form-control {
+      display: inline-block;
+    }
+
     [contenteditable].form-control,
     input[type='text'],
     input[type='number'],


### PR DESCRIPTION
The major browsers handle new lines in contenteditable blocks by inserting <div> tags. This causes invalid HTML when inserting the content into a <p> with the paragraph control and when constructing <label> tags. 

Setting display: inline-block forces the browsers to use a <br> tag instead for new lines.

Fixes https://github.com/kevinchappell/formBuilder/issues/1130