### PR TITLE
Fix loading of checkbox-group user data when default select state set in formData

### DIFF
--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -194,6 +194,12 @@ export default class controlSelect extends control {
           .val(selectedOptions)
           .prop('selected', true)
       } else if (this.config.type.endsWith('-group')) {
+        if (this.config.type === 'checkbox-group') {
+          //clear all checked elements prior to setting them from userData
+          this.dom.querySelectorAll('input[type=checkbox]').forEach(input => {
+            input.removeAttribute('checked')
+          })
+        }
         this.dom.querySelectorAll('input').forEach(input => {
           if (input.classList.contains('other-val')) {
             return


### PR DESCRIPTION
Ensure that default selected checkboxes are unselected when loading userData that doesn't contain them.

Fixes https://github.com/kevinchappell/formBuilder/issues/1164