### PR TITLE
Fix lookup of label value if not set in field definition

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1027,7 +1027,7 @@ function FormBuilder(opts, element, $) {
     data.lastID = h.incrementId(data.lastID)
 
     const type = values.type || 'text'
-    let label = values.label || (isNew ? i18n.get(type) || mi18n.get('label') : '')
+    let label = values.label || (isNew ? i18n[type] || mi18n.get('label') : '')
     if (type === 'hidden') {
       label = `${mi18n.get(type)}: ${values.name}`
     }


### PR DESCRIPTION
If a field is defined without a `label` attribute value the lookup will fail with a get() is not a function error. i18n does not have this method and needs to be queried by object key.