### PR TITLE
Fix incorrectly assigning a value to numberAttributes

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -882,8 +882,8 @@ function FormBuilder(opts, element, $) {
    * @return {String} markup for number attribute
    */
   const numberAttribute = (attribute, values) => {
-    const { class: classname, className, value, ...attrs } = values
-    const attrVal = (isNaN(attrs[attribute])) ? value : attrs[attribute]
+    const { class: classname, className, ...attrs } = values
+    const attrVal = (isNaN(attrs[attribute])) ? undefined : attrs[attribute]
     const attrLabel = mi18n.get(attribute) || attribute
     const placeholder = mi18n.get(`placeholder.${attribute}`)
 


### PR DESCRIPTION
fix: If no value was set for a numberAttribute the value attribute's)value was used instead. This causes min/max/step/rows/maxLen number attributes to incorrectly be assigned a value if they are not set in formData but a number exists in the value attribute

Fixes: https://github.com/kevinchappell/formBuilder/issues/999