### PR TITLE
Fix for fallback in removeField when no fieldID is provided (or fieldID is not found)

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1002,7 +1002,7 @@ export default class Helpers {
   }
 
   /**
-   * Remove a field from the stage
+   * Remove a given field from the stage or the last field if no fieldID is provided
    * @param  {String}  fieldID ID of the field to be removed
    * @param  {Number}  animationSpeed
    * @return {Boolean} fieldRemoved returns true if field is removed
@@ -1018,9 +1018,7 @@ export default class Helpers {
       return false
     }
 
-    const field = fieldID && document.getElementById(fieldID)
-
-    if (!fieldID || !field) {
+    if (!fieldID) {
       const availableIds = [].slice.call(fields).map(field => {
         return field.id
       })
@@ -1030,12 +1028,14 @@ export default class Helpers {
       fieldID = form.lastChild.id
     }
 
-    const $field = $(field)
-    const fieldRowWrapper = $field.closest(this.formBuilder.rowWrapperClassSelector)
+    const field = document.getElementById(fieldID)
     if (!field) {
       config.opts.notify.warning('Field not found')
       return false
     }
+
+    const $field = $(field)
+    const fieldRowWrapper = $field.closest(this.formBuilder.rowWrapperClassSelector)
 
     $field.slideUp(animationSpeed, function () {
       $field.removeClass('deleting')


### PR DESCRIPTION
fix: revert change made in https://github.com/kevinchappell/formBuilder/commit/e0c0f2ea8f204da6e11d8de938e27ca6687d5588 which declared field as a const prior to the fallback to selecting the last field in the form. This change also prevents incorrect removing of the last field in the case where a fieldID is provided but which was not found in the form

removeField will remove the field given in fieldID, or if no fieldID passed to the function then it will remove the last field in the form.

Fixes: https://github.com/kevinchappell/formBuilder/issues/1217