### PR TITLE
Fix GH-854 Show icon for custom controls on mobile phone screen sizes

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -110,7 +110,7 @@ export default class Controls {
         if (set.icon) {
           label = `<span class="control-icon">${set.icon}</span>${label}`
         }
-        const inputSet = m('li', label, {
+        const inputSet = m('li', m('span', label), {
           className: `input-set-control input-set-${i}`,
         })
         inputSet.dataset.type = name

--- a/src/sass/_controls.scss
+++ b/src/sass/_controls.scss
@@ -107,8 +107,17 @@
         font-size: 30px;
       }
 
+      & {
+        text-overflow: clip;
+      }
+
       span {
-        display: none;
+        visibility: hidden;
+        span {
+          visibility: visible;
+          font-size: 30px;
+          width: auto !important;
+        }
       }
     }
   }


### PR DESCRIPTION
When in small screen mode, ensure that the .control-icon is visible and sized the same as .frmb-control li::before

Adjust inputSet control to have the same element layout as custom controls to ensure CSS selectors apply

Fixes: #854 