### PR TITLE
Update docs to fix UTF-8 encoding issues

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,16 +14,20 @@ Once you have the module/plugin installed, include it in your build process for 
 
 ## Basic Example
 
+**Note**: The document charset should be set to utf-8 to ensure CSS font styles are rendered correctly 
+
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>Example formBuilder</title>
+  <!-- Required meta tag -->
+  <meta charset="utf-8">
+  <title>Example formBuilder</title>
 </head>
 <body>
   <div id="fb-editor"></div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
   <script src="https://formbuilder.online/assets/js/form-builder.min.js"></script>
   <script>
   jQuery(function($) {


### PR DESCRIPTION
Since the SASS processing was changed from node-sass to sass, the @charset=utf-8 for the styles is not carried through to the production minimised css. On systems where the HTML page is not with UTF-8 encoding set the css icons will be rendered incorrectly. The meta tag 'charset' should be set to utf-8, this is the same requirement as CSS libraries such as Bootstrap.

Update Getting Started documentation with a note about ensuring the charset for the document is set to utf-8 to ensure the CSS icon styles render correctly when the local charset is different

See: https://github.com/webpack-contrib/sass-loader/issues/973
See: https://github.com/sass/dart-sass/issues/1387
Closes: #1353 

Note: Bumped jQuery versions used in demo as any straight copy of the getting started will result in old and outdated versions being used by default.
