### PR TITLE
Ensure we remove bootstrap classes for child elements in the field

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -854,7 +854,7 @@ export default class Helpers {
       cleanResults.forEach(result => {
         if (result['columnInfo'].columnSize) {
           const currentClassRow = rowContainer.attr('class')
-          if (currentClassRow != result['columnInfo'].columnSize) {
+          if (currentClassRow !== result['columnInfo'].columnSize) {
             //Keep the wrapping column div sync'd to the column property from the field
             rowContainer.attr('class', `${result['columnInfo'].columnSize} ${this.formBuilder.colWrapperClass}`)
             _this.tmpCleanPrevHolder(prevHolder)
@@ -1288,13 +1288,16 @@ export default class Helpers {
     })
 
     function tmpCleanColumnInfo($field) {
-      var classAttr = $field.attr('class')
+      const classAttr = $field.attr('class')
 
       if (typeof classAttr !== 'undefined' && classAttr !== false) {
         const parseResult = _this.tryParseColumnInfo($field[0])
 
-        $field.attr('class', $field.attr('class').replace('col-', 'tmp-col-'))
-        $field.attr('class', $field.attr('class').replace('row', 'tmp-row'))
+        //tmpCleanColumnInfo may be called multiple times, remove previous work to ensure we don't keep appending tmp- to class names
+        $field.attr('class', $field.attr('class').replace('__fb-tmp-col-', 'col-' ))
+        $field.attr('class', $field.attr('class').replace('__fb-tmp-row-', 'row-' ))
+        $field.attr('class', $field.attr('class').replace('col-', '__fb-tmp-col-'))
+        $field.attr('class', $field.attr('class').replace('row-', '__fb-tmp-row-'))
 
         const result = {}
         result['field'] = $field

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -14,10 +14,16 @@ const processClassName = (data, field) => {
       className += ` ${classes.join(' ')}`
     }
 
-    // Now that the col- types were lifted, remove from the actual input field
+    // Now that the row- & col- types were lifted, remove from the actual input field and any child elements
     if (field.classList) {
       field.classList.remove(...classes)
     }
+
+    field.querySelectorAll('[class*=row-],[class*=col-]').forEach(element => {
+      if (element.classList) {
+        element.classList.remove(...classes)
+      }
+    })
   }
 
   return className


### PR DESCRIPTION
col- and row- classes were not removed from fields that are more complex than a simple input element (e.g. checkbox-groups).

tmpCleanColumnInfo() could be called multiple times leading classnames to have tmp- appended multiple times (eg tmp-tmp-row-1), ensure we don't keep applying the change by removing any applied tmp- values before reapplying

tmpCleanColumnInfo would append tmp- to any classname found containing the word 'row', adjust replacement to only replace row- values