### PR TITLE
Ensure we do not corrupt the userTypeAttr definition when encountering a boolean false value

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -697,8 +697,8 @@ function FormBuilder(opts, element, $) {
         if (attrValType !== 'undefined') {
           const orig = mi18n.get(attribute)
           const tUA = typeUserAttr[attribute]
-          const origValue = tUA.value || ''
-          tUA.value = values[attribute] || tUA.value || ''
+          const origValue = attrValType === 'boolean' ? tUA.value : (tUA.value || '')
+          tUA.value = values[attribute] || origValue
 
           if (tUA.label) {
             i18n[attribute] = Array.isArray(tUA.label) ? mi18n.get(...tUA.label) || tUA.label[0] : tUA.label


### PR DESCRIPTION
When a user configured a userTypeAttr with `value: false` but no `type: checkbox` the origValue calculation in processTypeUserAttrs would set the  _false_ to _''_ , this would cause the typeUserAttrs value definition to be changed when resetting the tUA.value to the original value.

This had the affect that when additional fields are added with this typeUserAttrs, processTypeUserAttrs would see the value as type string and output a textbox instead of a checkbox.

value: true would be detected as boolean and always kept as boolean. This PR ensures value: false works the same way.

One of the issues raised in https://github.com/kevinchappell/formBuilder/issues/915