### PR TITLE
Warn when a typeUserAttr definition is unable to be processed instead of silently ignoring

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -713,7 +713,9 @@ function FormBuilder(opts, element, $) {
         } else if (attrValType === 'undefined' && hasSubType(values, attribute)) {
           advField.push(processTypeUserAttrs(typeUserAttr[attribute], values))
         } else {
-          continue
+          const def = {}
+          def[attribute] = typeUserAttr[attribute]
+          opts.notify.warning('Warning: unable to process typeUserAttr definition : ' + JSON.stringify(def))
         }
       }
     }

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -652,7 +652,7 @@ function FormBuilder(opts, element, $) {
         ['array', ({ options }) => !!options],
         ['boolean', ({ type }) => type === 'checkbox'], // automatic bool if checkbox
         [typeof attrData.value, () => true], // string, number,
-      ].find(typeCondition => typeCondition[1](attrData))[0] || 'string'
+      ].find(typeCondition => typeCondition[1](attrData))[0]
     )
   }
 


### PR DESCRIPTION
Issue raised in https://github.com/kevinchappell/formBuilder/issues/915

The codepen on https://formbuilder.online/docs/formBuilder/options/typeUserAttrs/#example-number-inputs defines min and max fields without setting a value: for processTypeUserAttrs to detect the type. The definition is then silently ignored instead of raising a warning

Additionally the fallback check in userAttrType can not be called because the last check `() => true` will always be true and `typeof attrData.value` will always return a string value, additionally the subType user attribute function expects this to return the 'undefined' string from typeof to trigger subType processing so a fallback is not expected