### PR TITLE
Complete disableHTMLLabels feature

### DIFF
--- a/docs/formRender/options.md
+++ b/docs/formRender/options.md
@@ -5,6 +5,7 @@ var defaults = {
   container: false,
   formData: false,
   dataType: 'json', // 'xml' | 'json'
+  disableHTMLLabels: false,
   label: {
     formRendered: 'Form Rendered',
     noFormData: 'No form data.',

--- a/docs/formRender/options/disableHTMLLabels.md
+++ b/docs/formRender/options/disableHTMLLabels.md
@@ -1,0 +1,2 @@
+# disableHTMLLabels
+Disables HTML labels.

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -69,7 +69,7 @@ function FormBuilder(opts, element, $) {
   if (!opts.layout) {
     opts.layout = layout
   }
-  const layoutEngine = new opts.layout(opts.layoutTemplates, true)
+  const layoutEngine = new opts.layout(opts.layoutTemplates, true, opts.disableHTMLLabels)
 
   const h = new Helpers(formID, layoutEngine, formBuilder)
   const m = markup
@@ -1083,8 +1083,9 @@ function FormBuilder(opts, element, $) {
 
     const liContents = [m('div', fieldButtons, { className: 'field-actions' })]
 
+    const labelValue = opts.disableHTMLLabels ? document.createTextNode(label) : parsedHtml(label)
     liContents.push(
-      m('label', parsedHtml(label), {
+      m('label', labelValue, {
         className: 'field-label',
       }),
     )
@@ -1739,7 +1740,11 @@ function FormBuilder(opts, element, $) {
     if (!target.classList.contains('fld-label')) return
     const value = target.value || target.innerHTML
     const label = closest(target, '.form-field').querySelector('.field-label')
-    label.innerHTML = parsedHtml(value)
+    if (config.opts.disableHTMLLabels) {
+      label.textContent = value
+    } else {
+      label.innerHTML = parsedHtml(value)
+    }
   })
 
   // remove error styling when users tries to correct mistake

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -26,6 +26,7 @@ class FormRender {
       controlConfig: {}, // additional configuration for controls
       container: false, // string selector or Node element
       dataType: 'json',
+      disableHTMLLabels: false,
       formData: false,
       i18n: Object.assign({}, defaultI18n),
       messages: {
@@ -187,7 +188,7 @@ class FormRender {
     // generate field markup if we have fields
     if (opts.formData) {
       // instantiate the layout class & loop through the field configuration
-      const engine = new opts.layout(opts.layoutTemplates)
+      const engine = new opts.layout(opts.layoutTemplates, false, opts.disableHTMLLabels)
       for (let i = 0; i < opts.formData.length; i++) {
         const fieldData = opts.formData[i]
         const sanitizedField = this.santizeField(fieldData, instanceIndex)

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -39,9 +39,11 @@ export default class layout {
    * Prepare the templates for layout
    * @param {Object} templates object containing custom or overwrite templates
    * @param {Boolean} preview - are we rendering a preview for the formBuilder stage
+   * @param {Boolean} disableHTMLLabels - do we render labels as HTML or plain text
    */
-  constructor(templates, preview) {
-    this.preview = preview
+  constructor(templates, preview = false, disableHTMLLabels = false) {
+    this.preview = preview ?? false
+    this.disableHTMLLabels = disableHTMLLabels ?? false
 
     // supported templates for outputting a field
     // preferred layout template can be indicated by specifying a 'layout' in the return object of control::build
@@ -141,7 +143,7 @@ export default class layout {
    */
   label() {
     const label = this.data.label || ''
-    const labelText = utils.parsedHtml(label)
+    const labelText = this.disableHTMLLabels ? document.createTextNode(label) : utils.parsedHtml(label)
     const labelContents = [labelText]
     if (this.data.required) {
       labelContents.push(this.markup('span', '*', { className: 'formbuilder-required' }))


### PR DESCRIPTION
disableHTMLLabels in formBuilder only changed .fld-label from a contenteditable to input[type=text]. HTML could still be written into the input and the keyup/change event handler would update the label as HTML. formBuilder would also render any html in labels set in formData on initialisation of the form.

Additionally formRender had no support for disableHTMLLabels and therefore would render the labels as HTML when rendering userData

This PR completes the intent of the disableHTMLLabels feature

- Add disableHTMLLabels option to formRender
- layout class now accepts a third optional constructor parameter disableHTMLLabels. Extended classes of layout should take this into account
- Ensure disableHTMLLabels option is honoured in the three places where the label is rendered (layout.label(), formBuilder.appendNewField(), d.stage keyup/change event handler for label .fld-label). This is done by adding the label text into a Text node when constructing the label element and assigning to textContent in the event handler 

Fixes: https://github.com/kevinchappell/formBuilder/issues/1324