### PR TITLE
Fix insertion position for new controls when append or prepend options are enabled

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -2326,12 +2326,12 @@ function FormBuilder(opts, element, $) {
     let swap
     if ($(evt.target).hasClass('sort-button-higher')) {
       swap = currentItem.prev('li')
-      if (swap.length) {
+      if (swap.length && !swap.hasClass('form-prepend')) {
         currentItem.insertBefore(swap)
       }
     } else {
       swap = currentItem.next('li')
-      if (swap.length) {
+      if (swap.length && !swap.hasClass('form-append')) {
         currentItem.insertAfter(swap)
       }
     }

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -280,7 +280,7 @@ function FormBuilder(opts, element, $) {
       $stage.prepend(disabledField('prepend'))
     }
 
-    if (opts.append && !$('.disabled-field.form-.append', d.stage).length) {
+    if (opts.append && !$('.disabled-field.form-append', d.stage).length) {
       cancelArray.push(true)
       $stage.append(disabledField('append'))
     }

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -255,7 +255,7 @@ function FormBuilder(opts, element, $) {
     }
 
     const $control = $(target).closest('li')
-    h.stopIndex = undefined
+    h.stopIndex = opts.append ? d.stage.childNodes.length - 1 : undefined
     processControl($control)
     h.save.call(h)
   })

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -131,6 +131,13 @@ function FormBuilder(opts, element, $) {
       revert: 150,
       beforeStop: (evt, ui) => h.beforeStop.call(h, evt, ui),
       distance: 3,
+      change: function(event, ui) {
+        if (opts.prepend && ui.placeholder.index() < 1) {
+          $('li.form-prepend').after(ui.placeholder)
+        } else if (opts.append && ui.placeholder.index() >=(d.stage.childNodes.length - 1)) {
+          $('li.form-append').before(ui.placeholder)
+        }
+      },
       update: function (event, ui) {
         if (h.doCancel) {
           return false


### PR DESCRIPTION
This PR fixes the following issues:

- Dragging a control onto the stage before a prepended field or after a appended field would show the drop placeholder and then silently cancel the drop on cursor release. We can fix this by relocating the placeholder with the jquery-ui.sortable change event
- Adding a field by clicking on the control would insert the new control after a prepended field. Correctly set h.stopIndex to ensure controls are added before the prepended field
- When sorting stage controls using the mobile sort buttons the sort handler did not take into account appended/prepended fields

Partial fix for #665

 