### PR TITLE
Remove unreachable branch is dblClick handler

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1689,8 +1689,7 @@ function FormBuilder(opts, element, $) {
     e.stopPropagation()
     e.preventDefault()
     if (e.handled !== true) {
-      const targetID =
-        e.target.tagName == 'li' ? $(e.target).attr('id') : $(e.target).closest('li.form-field').attr('id')
+      const targetID = $(e.target).closest('li.form-field').attr('id')
       h.toggleEdit(targetID)
       e.handled = true
     }


### PR DESCRIPTION
TagName is always upper case for HTML5 (ie LI not li), so the comparison will always be false. Luckily this has always worked because $().closest can be used for both cases as closest() starts traversal from the current element