### PR TITLE
Implement built-in XSS and DOM Clobbering protection

### DIFF
--- a/docs/formBuilder/controls.md
+++ b/docs/formBuilder/controls.md
@@ -1,6 +1,6 @@
 # Control architecture
 
-Controls defined in this directory will be transpiled into the core `formBuilder` & `formRender` plugins. Only 'core' regularly used plugins should be included here. Plugins that have less common use-cases should be added as [control plugins](control-plugins) which are only loaded as required.
+Controls defined in this directory will be transpiled into the core `formBuilder` & `formRender` plugins. Only 'core' regularly used plugins should be included here. Plugins that have less common use-cases should be added as [control plugins](control-plugins.md) which are only loaded as required.
 
 All control classes should inherit from `src/js/control.js`. Each class can support one or more `types` or `subtypes`.
 

--- a/docs/formBuilder/options/i18n.md
+++ b/docs/formBuilder/options/i18n.md
@@ -19,4 +19,4 @@ $(container).formBuilder(options);
 ## See it in Action
 <p data-height="494" data-theme-id="22927" data-embed-version="2" data-slug-hash="rmxYVW" data-default-tab="result" data-user="kevinchappell" class="codepen"></p>
 
-For a more advanced example see: [Demos->Translation](/demos/translation/)
+For a more advanced example see: [Demos->Translation](../demos/translation.md)

--- a/docs/formBuilder/options/sanitizerOptions.md
+++ b/docs/formBuilder/options/sanitizerOptions.md
@@ -1,0 +1,61 @@
+# SanitizerOptions
+`sanitizerOptions` provides the configuration of the built-in script injection, DOM Clobbering and Form hijacking protection.
+
+This protection is disabled by default, however should be enabled when any of the following apply:
+* Input into fields may be copy/pasted from untrusted sources (especially Label field or paragraph Content field)
+* Untrusted users may build forms
+
+In a future version of FormBuilder protections may be enabled by default.
+
+_Script injection_ protection will remove `<script>` elements, inline javascript, and on* event attributes from FormElements when rendering the FormBuilder previews and FormRender forms. Additionally invalid or incomplete HTML will be cleaned up.
+
+_DOM Clobbering_ protection will remove _id_ and _name_ attribute values which cause attributes in the Document and Form DOM objects to be overwritten.
+
+_Form Protection_ will ensure than buttons cannot override the form action nor act upon another form.
+
+## Enabling protections
+```javascript
+const sanitizerOptions = {
+  clobberingProtection: {
+    document: true,
+    form: false, //Set true for FormRender
+  },
+  backendOrder: ['dompurify','sanitizer','fallback'],
+};
+$(container).formBuilder(options);
+```
+
+## Sanitizer backends
+
+FormBuilder supports three Sanitizer backends:
+- DomPurify
+- Sanitizer API
+- jQuery based fallback
+
+### DomPurify
+To enable support for the DomPurify backend the Javascript library should be included before FormBuilder is included on your page.
+
+Information on installing DomPurify can be found on the project page https://github.com/cure53/DOMPurify
+
+### Sanitizer API
+Sanitizer API is an experimental web feature being implemented by the major web browsers. The Sanitizer backend will use this API if it is detected in the browser.
+
+### jQuery based fallback
+A built-in fallback method is provided when DomPurify an Sanitizer API is not enabled or available.
+
+## DOM Clobbering
+DOM clobbering prevention can be enabled to protect the attributes of the global document dom element and any wrapping `<form>` element.
+
+Optionally instead of removing offending _id_ or _name_ attributes the Dom Clobbering protection can be configured to prepend the namespace 'user-content-' (Similar to DomPurify SANITIZE_NAMED_PROPS)
+
+```javascript
+const sanitizerOptions = {
+  clobberingProtection: {
+    document: true,
+    form: false, //Set true for FormRender
+    namespaceAttributes: true,
+  },
+  backendOrder: ['dompurify','sanitizer','fallback'],
+};
+$(container).formBuilder(options);
+```

--- a/docs/formBuilder/overview.md
+++ b/docs/formBuilder/overview.md
@@ -18,9 +18,9 @@ Key files / folders:
 
  Each control is represented by a class which inherits from the `control` class defined in `control.js`. A control class may be used by multiple types of controls.
  
- For an example in of how to [**create a new control**](controls), check out the Readme.md in the `control/` directory. 
+ For an example in of how to [**create a new control**](controls.md), check out the Readme.md in the `control/` directory. 
  
- For an example in of how to [**create a new control plugin**](control-plugins), check out the Readme.md in the `control/` directory.
+ For an example in of how to [**create a new control plugin**](control-plugins.md), check out the Readme.md in the `control/` directory.
  
  The parent class defined in `control.js` has two types of methods:
    * object level methods which are used to manipulate and create an instance of that control on a form

--- a/docs/formBuilder/overview.md
+++ b/docs/formBuilder/overview.md
@@ -9,6 +9,7 @@ Key files / folders:
   * `form-render.js` - the library & code for rendering formData json/xml created by formbuilder
   * `helper.js` - reusable methods that are used throughout `form-builder.js`
   * `layout.js` - the layout engine that produces each row of the form, and determines how the label, help text, and control widget will each fit together.
+  * `sanitizer.js` - Script injection and DOM clobbering protection library for formbuilder
   * `utils.js` - resuable methods thare are used in both `form-builder.js` and `form-render.js`
   
 # Controls

--- a/docs/formRender/options.md
+++ b/docs/formRender/options.md
@@ -23,6 +23,13 @@ var defaults = {
     warning: function(message) {
       return console.warn(message);
     }
-  }
+  },
+  sanitizerOptions: {
+    clobberingProtection: {
+      document: false,
+      form: false,
+    },
+    backendOrder: ['dompurify','sanitizer','fallback'],
+  },
 }
 </code></pre>

--- a/docs/formRender/options/sanitizerOptions.md
+++ b/docs/formRender/options/sanitizerOptions.md
@@ -1,0 +1,4 @@
+# SanitizerOptions
+`sanitizerOptions` provides the configuration of the built-in script injection, DOM Clobbering and Form hijacking protection.
+
+Documentation is provided for this option in the FormBuilder [sanitizeOptions](../../formBuilder/options/sanitizerOptions.md) page

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,7 +77,7 @@ nav:
   - persistDefaultFields: formBuilder/options/persistDefaultFields.md
   - replaceFields: formBuilder/options/replaceFields.md
   - roles: formBuilder/options/roles.md
-  - sanitizerOptions: formRender/options/sanitizerOptions.md
+  - sanitizerOptions: formBuilder/options/sanitizerOptions.md
   - scrollToFieldOnAdd: formBuilder/options/scrollToFieldOnAdd.md
   - showActionButtons: formBuilder/options/showActionButtons.md
   - sortableControls: formBuilder/options/sortableControls.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
 - formBuilder Demos:
   - AngularJS: formBuilder/demos/angular.md
   - Basic: formBuilder/demos/basic.md
+  - Bootstrap Grid: formBuilder/demos/bootstrap-grid.md
   - Custom Elements: formBuilder/options/templates.md
   - Data: formBuilder/demos/data.md
   - React: formBuilder/demos/react.md
@@ -76,6 +77,7 @@ nav:
   - persistDefaultFields: formBuilder/options/persistDefaultFields.md
   - replaceFields: formBuilder/options/replaceFields.md
   - roles: formBuilder/options/roles.md
+  - sanitizerOptions: formRender/options/sanitizerOptions.md
   - scrollToFieldOnAdd: formBuilder/options/scrollToFieldOnAdd.md
   - showActionButtons: formBuilder/options/showActionButtons.md
   - sortableControls: formBuilder/options/sortableControls.md
@@ -98,10 +100,12 @@ nav:
 - formRender Options:
   - Overview: formRender/options.md
   - container: formRender/options/container.md
+  - disableHTMLLabels: formRender/options/disableHTMLLabels.md
   - formData: formRender/options/formData.md
   - layout: formRender/options/layout.md
   - layoutTemplates: formRender/options/layoutTemplates.md
   - render: formRender/options/render.md
+  - sanitizerOptions: formRender/options/sanitizerOptions.md
 - Contributing: contributing.md
 - License: license.md
 extra_css:

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -70,10 +70,10 @@ export const defaultOptions = {
   },
   sanitizerOptions: {
     clobberingProtection: {
-      document: true,
+      document: false,
       form: false,
     },
-    backendOrder: ['dompurify','sanitizer','fallback'],
+    backendOrder: [], //'dompurify','sanitizer','fallback'
   },
   scrollToFieldOnAdd: true,
   showActionButtons: true,

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -68,6 +68,7 @@ export const defaultOptions = {
   roles: {
     1: 'Administrator',
   },
+  sanitizerOptions: {},
   scrollToFieldOnAdd: true,
   showActionButtons: true,
   sortableControls: false,

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -68,7 +68,13 @@ export const defaultOptions = {
   roles: {
     1: 'Administrator',
   },
-  sanitizerOptions: {},
+  sanitizerOptions: {
+    clobberingProtection: {
+      document: true,
+      form: false,
+    },
+    backendOrder: ['dompurify','sanitizer','fallback'],
+  },
   scrollToFieldOnAdd: true,
   showActionButtons: true,
   sortableControls: false,

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -35,7 +35,7 @@ import {
   getContentType,
   generateSelectorClassNames,
 } from './utils'
-import { setElementContent, setSanitizerConfig } from './sanitizer'
+import { attributeWillClobber, setElementContent, setSanitizerConfig } from './sanitizer'
 import fontConfig from '../fonts/config.json'
 const css_prefix_text = fontConfig.css_prefix_text
 
@@ -1714,10 +1714,9 @@ function FormBuilder(opts, element, $) {
     $valWrap.toggle(e.target.value !== 'quill')
   })
 
-  const testForm = document.createElement('form')
   $stage.on('change', '[name="name"]', e => {
     const name = e.target.value
-    if (name in document || name in testForm) {
+    if (attributeWillClobber(name)) {
       //@TODO Notify the user of this potential issue
       opts.notify.error('Potential for Dom Clobbering with field name ' + name)
     }

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -35,6 +35,7 @@ import {
   getContentType,
   generateSelectorClassNames,
 } from './utils'
+import { setElementContent, setSanitizerConfig } from './sanitizer'
 import fontConfig from '../fonts/config.json'
 const css_prefix_text = fontConfig.css_prefix_text
 
@@ -65,6 +66,13 @@ function FormBuilder(opts, element, $) {
   formBuilder.colWrapperClass = colWrapperClass
   formBuilder.fieldSelector = opts.enableEnhancedBootstrapGrid ? rowWrapperClassSelector : defaultFieldSelector
 
+  //Initialise HTML sanitizer
+  setSanitizerConfig(opts.sanitizerOptions)
+  if ($(element).closest('form').length) {
+    //Due to Dom Clobbering potential with the stage and the lack of requirement for a Form element, warn for this type of setup
+    opts.notify.warning('WARNING: FormBuilder does not support being contained with a <form> Element')
+  }
+
   // prepare a new layout object with appropriate templates
   if (!opts.layout) {
     opts.layout = layout
@@ -93,11 +101,7 @@ function FormBuilder(opts, element, $) {
   let cloneControls
 
   function enhancedBootstrapEnabled() {
-    if (!opts.enableEnhancedBootstrapGrid) {
-      return false
-    }
-
-    return true
+    return !!opts.enableEnhancedBootstrapGrid
   }
 
   $stage.sortable({
@@ -1710,6 +1714,15 @@ function FormBuilder(opts, element, $) {
     $valWrap.toggle(e.target.value !== 'quill')
   })
 
+  const testForm = document.createElement('form')
+  $stage.on('change', '[name="name"]', e => {
+    const name = e.target.value
+    if (name in document || name in testForm) {
+      //@TODO Notify the user of this potential issue
+      opts.notify.error('Potential for Dom Clobbering with field name ' + name)
+    }
+  })
+
   const stageOnChangeSelectors = ['.prev-holder input', '.prev-holder select', '.prev-holder textarea']
   $stage.on('change', stageOnChangeSelectors.join(', '), e => {
     let prevOptions
@@ -1748,11 +1761,7 @@ function FormBuilder(opts, element, $) {
     if (!target.classList.contains('fld-label')) return
     const value = target.value || target.innerHTML
     const label = closest(target, '.form-field').querySelector('.field-label')
-    if (config.opts.disableHTMLLabels) {
-      label.textContent = value
-    } else {
-      label.innerHTML = parsedHtml(value)
-    }
+    setElementContent(label, parsedHtml(value), config.opts.disableHTMLLabels)
   })
 
   // remove error styling when users tries to correct mistake
@@ -2210,7 +2219,7 @@ function FormBuilder(opts, element, $) {
       gridMode = false
       gridModeTargetField = null
 
-      $(gridModeHelp).html('')
+      $(gridModeHelp).empty()
 
       //Show controls
       $cbUL.css('display', 'unset')
@@ -2220,7 +2229,7 @@ function FormBuilder(opts, element, $) {
 
   function buildGridModeHelp() {
     $(gridModeHelp).html(`
-    <div style='padding:5px'>    
+    <div style='padding:5px'>
       <h3 class="text text-center">Grid Mode</h3>    
       
       <table style='border-spacing:7px;border-collapse: separate'>

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -39,7 +39,15 @@ class FormRender {
       },
       onRender: () => {},
       render: true,
-      sanitizerOptions: {},
+      sanitizerOptions: {
+        clobberingProtection: {
+          document: true,
+          form: false,
+          namespaceAttributes: true, //clobbered names will be prefixed with user-content-
+        },
+        backendOrder: ['dompurify','sanitizer','fallback'],
+
+      },
       templates: {}, // custom inline defined templates
       notify: {
         error: error => {

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -8,6 +8,7 @@ import './control/index'
 import controlCustom from './control/custom'
 import { defaultI18n } from './config'
 import '../sass/form-render.scss'
+import { setSanitizerConfig } from './sanitizer'
 
 /**
  * FormRender Class
@@ -38,6 +39,7 @@ class FormRender {
       },
       onRender: () => {},
       render: true,
+      sanitizerOptions: {},
       templates: {}, // custom inline defined templates
       notify: {
         error: error => {
@@ -53,6 +55,9 @@ class FormRender {
     }
     this.options = jQuery.extend(true, defaults, options)
     this.instanceContainers = []
+
+    //Override any sanitizer configuration
+    setSanitizerConfig(this.options.sanitizerOptions)
 
     if (!mi18n.current) {
       mi18n.init(this.options.i18n)
@@ -134,7 +139,7 @@ class FormRender {
    * @param {Number} instanceIndex - instance index
    * @return {Object} sanitized field object
    */
-  santizeField(field, instanceIndex) {
+  sanitizeField(field, instanceIndex) {
     const sanitizedField = Object.assign({}, field)
     if (instanceIndex) {
       sanitizedField.id = field.id && `${field.id}-${instanceIndex}`
@@ -191,7 +196,7 @@ class FormRender {
       const engine = new opts.layout(opts.layoutTemplates, false, opts.disableHTMLLabels)
       for (let i = 0; i < opts.formData.length; i++) {
         const fieldData = opts.formData[i]
-        const sanitizedField = this.santizeField(fieldData, instanceIndex)
+        const sanitizedField = this.sanitizeField(fieldData, instanceIndex)
 
         // determine the control class for this type, and then process it through the layout engine
         const controlClass = control.getClass(fieldData.type, fieldData.subtype)
@@ -249,7 +254,7 @@ class FormRender {
         'To render a single element, please specify a single object of formData for the field in question',
       )
     }
-    const sanitizedField = this.santizeField(fieldData)
+    const sanitizedField = this.sanitizeField(fieldData)
 
     // determine the control class for this type, and then build it
     const engine = new opts.layout()

--- a/src/js/sanitizer.js
+++ b/src/js/sanitizer.js
@@ -132,7 +132,7 @@ export const setElementContent = (element, content, asText = false) => {
     element.textContent = content
   } else {
     const proxyElem = document.createElement(element.tagName)
-    const performedBy = ['sanitizer','dompurify','fallback'].find(type => sanitizersCallbacks[type](proxyElem, content))
+    const performedBy = ['dompurify','sanitizer','fallback'].find(type => sanitizersCallbacks[type](proxyElem, content))
     if (performedBy !== undefined) {
       sanitizeDomClobbering(proxyElem, '')
     }

--- a/src/js/sanitizer.js
+++ b/src/js/sanitizer.js
@@ -130,16 +130,19 @@ export const setSanitizerConfig = config => {
   }
 }
 
+export const attributeWillClobber = value => {
+  const check_doc = document
+  const check_form = document.createElement('form')
+
+  return (value in check_doc || value in check_form)
+}
+
 export const sanitizeNamedAttribute = value => {
   const check_doc = sanitizerConfig.clobberingProtection.document ? document : false
   const check_form = sanitizerConfig.clobberingProtection.form ? document.createElement('form') : false
 
   if ((check_doc && value in check_doc) || (check_form && value in check_form)) {
-    if (sanitizerConfig.clobberingProtection.namespaceAttributes) {
-      return 'user-content-' + value
-    } else {
-      return undefined
-    }
+    return (sanitizerConfig.clobberingProtection.namespaceAttributes) ? 'user-content-' + value : undefined
   }
   return value
 }
@@ -213,7 +216,8 @@ const sanitizer = {
   setElementContent,
   setSanitizerConfig,
   sanitizeNamedAttribute,
-  isPotentiallyDangerousAttribute
+  isPotentiallyDangerousAttribute,
+  attributeWillClobber,
 }
 
 export default sanitizer

--- a/src/js/sanitizer.js
+++ b/src/js/sanitizer.js
@@ -86,7 +86,7 @@ const sanitizerConfig = {
     dompurify: window.DOMPurify ? (purify => {
       purify.setConfig({
         //USE_PROFILES: { html: true }, //Only process HTML (exclude SVG and MATHML)
-        SANITIZE_DOM: false, //formBuilder uses inputs with names that clash built-in attributes of Form element, we use our modified DomClobbing function instead
+        SANITIZE_DOM: false, //formBuilder uses inputs with names that clash built-in attributes of Form element, we use our modified DomClobbering function instead
         ADD_ATTR: ['contenteditable'] //label input requires this to be allowed
       })
       return purify

--- a/src/js/sanitizer.js
+++ b/src/js/sanitizer.js
@@ -1,0 +1,148 @@
+/**
+ * Sanitizer utility for handling untrusted HTML
+ */
+
+const sanitizerConfig = {
+  sanitizer: typeof window['Sanitizer'] === 'function' ? new window.Sanitizer() : false,
+  dompurify: window.DOMPurify ? (purify => {
+    purify.setConfig({
+      //USE_PROFILES: { html: true }, //Only process HTML (exclude SVG and MATHML)
+      SANITIZE_DOM: false, //formBuilder uses inputs with names that clash built-in attributes of Form element, we use our modified DomClobbing function instead
+      ADD_ATTR: ['contenteditable'] //label input requires this to be allowed
+    })
+    return purify
+  })(window.DOMPurify) : false,
+  fallback: content => {
+    //Fallback function if no other sanitizer is available
+
+    //jQuery < 3.5 doesn't have this safety feature, so we implement it here
+    // Stop scripts or inline event handlers from being executed immediately
+    // by using document.implementation
+    const context = document.implementation.createHTMLDocument('')
+
+    // Set the base href for the created document
+    // so any parsed elements with URLs
+    // are based on the document's URL
+    const base = context.createElement('base')
+    base.href = document.location.href
+    context.head.appendChild(base)
+
+    const exclude_tags = [
+      'applet',
+      'comment',
+      'embed',
+      'iframe',
+      'link',
+      'listing',
+      'meta',
+      'noscript',
+      'object',
+      'plaintext',
+      'script',
+      'style',
+      'xmp',
+    ]
+
+    const output = $.parseHTML(content, context, false)
+    $(output).find('*').addBack().each((nindex, node) => {
+      if (node.nodeName === '#text') {
+        return //Allow through text nodes
+      }
+
+      //Strip potentially dangerous tags
+      if (node.tagName && exclude_tags.includes(node.tagName.toLowerCase())) {
+        if (node.parentElement) {
+          node.parentElement.removeChild(node)
+        } else if (output.includes(node)) {
+          output.splice(output.indexOf(node), 1)
+        }
+        return
+      }
+
+      //Strip attributes that can execute Javascript or cause dom clobbering
+      if (node.attributes) {
+        Array.from(node.attributes).forEach(attribute => {
+          const attrNameLc = attribute.name.toLowerCase()
+          if (
+            attrNameLc.startsWith('on')
+            || ['form','formaction'].includes(attrNameLc)
+            || attribute.value.trim().toLowerCase().startsWith('javascript:')
+          ) {
+            $(node).removeAttr(attribute.name)
+          }
+        })
+      }
+    })
+
+    const tmp = context.createElement('div')
+    $(tmp).html(output)
+    return tmp.innerHTML
+  }
+}
+
+export const setSanitizerConfig = config => { Object.keys(config).forEach(implementation => sanitizerConfig[implementation] = config[implementation]) }
+
+const sanitizeDomClobbering = element => {
+  $(element).find('*').each((nindex, node) => {
+    //Prevent dom clobbering of document.X from Element.name
+    if (['embed', 'form', 'iframe', 'image', 'img', 'object'].includes(node.tagName.toLowerCase())) {
+      node.removeAttribute('name')
+    }
+
+    ['id','name'].forEach(attrName => {
+      if (node.hasAttribute(attrName) && (node.getAttribute(attrName) in document)) { //@TODO for formRender we should also ensure no DomClobbering for Form
+        node.removeAttribute(attrName)
+      }
+    })
+  })
+  return element
+}
+
+const sanitizersCallbacks = {
+  fallback: (element, content) => {
+    //fallback will return the content as-is if the fallback is disabled
+    const purifier = sanitizerConfig.fallback
+    const supported = typeof purifier === 'function'
+    if (supported) {
+      content = purifier(content)
+    }
+    element.innerHTML = content
+    return supported
+  },
+  dompurify: (element, content) => {
+    const purifier = sanitizerConfig.dompurify
+    if (purifier === false || !purifier.isSupported) {
+      return false
+    }
+
+    element.innerHTML = purifier.sanitize(content)
+    return true
+  },
+  sanitizer: (element, content) => {
+    const sanitizer = sanitizerConfig.sanitizer
+    if (sanitizer) {
+      element.setHTML(content, {sanitizer: sanitizer})
+    }
+    return false
+  }
+}
+
+export const setElementContent = (element, content, asText = false) => {
+  if (asText) {
+    element.textContent = content
+  } else {
+    const proxyElem = document.createElement(element.tagName)
+    const performedBy = ['sanitizer','dompurify','fallback'].find(type => sanitizersCallbacks[type](proxyElem, content))
+    if (performedBy !== undefined) {
+      sanitizeDomClobbering(proxyElem, '')
+    }
+    element.innerHTML = proxyElem.innerHTML
+  }
+}
+
+const sanitizer = {
+  setElementContent,
+  setSanitizerConfig,
+}
+
+export default sanitizer

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,3 +1,4 @@
+import { setElementContent } from './sanitizer'
 /**
  * Cross file utilities for working with arrays,
  * sorting and other fun stuff
@@ -211,7 +212,7 @@ export const markup = function (tag, content = '', attributes = {}) {
 
   const appendContent = {
     string: content => {
-      field.innerHTML += content
+      setElementContent(field,field.innerHTML + content)
     },
     object: config => {
       const { tag, content, ...data } = config

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -239,6 +239,7 @@ export const markup = function (tag, content = '', attributes = {}) {
     if (attrs.hasOwnProperty(attr)) {
       const name = safeAttrName(attr)
       let attrVal = Array.isArray(attrs[attr]) ? unique(attrs[attr].join(' ').split(' ')).join(' ') : attrs[attr]
+      //If the Sanitizer is disabled this will always return false
       if (isPotentiallyDangerousAttribute(name, attrVal)) {
         continue
       }


### PR DESCRIPTION
Sanitizer is implemented with support for different backends: the experimental Sanitizer API (currently supported by Chrome and Edge), DomPurify, and a fallback jQuery sanitizer implementation, each will be tried in order until one is successful. DomPurify need to be included prior to formBuilder/formRender being initialised.

Sanitizer and DomPurify can be configured by passing in a new configured instance of their respective Class via the sanitizerOptions option. The fallback function can be overridden with a new function the same way.

Backends can be disabled by passing in a false value for that backend via the sanitizerOptions option. All sanitization can be disabled by setting all backends to false

sanitizerOptions = {
  sanitizer: false,
  dompurify: false,
  fallback: false
}

Each backend has been tested against a variety of inputs from https://github.com/mjfroman/moz-libwebrtc-third-party/blob/980ec542e93f88658089ee4ac78fc3dcfd066847/blink/web_tests/wpt_internal/sanitizer-api/support/testcases.sub.js and DomPurify