### PR TITLE
Change Deploy website trigger

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,16 +1,17 @@
 name: Deploy Website
 
 on:
-  release:
+  workflow_run:
+    workflows: [Publish]
     types:
-      - published
+      - completed
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  build:
+  on-success:
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v3
@@ -32,6 +32,10 @@ jobs:
         env:
           CI: true
         run: npm install
+
+      - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
+        run: npm audit signatures
+
       - name: Build the plugin
         run: npm run build
 
@@ -45,19 +49,3 @@ jobs:
         run: |
           VERSION=$(jq -r ".version" package.json)
           echo "::set-output name=version::$VERSION"
-
-      - name: Deploy the website
-        env:
-          VERSION: ${{ steps.get_version.outputs.version }}
-          TOKEN: ${{ secrets.FORMBUILDER_SITE_PAT }}
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-
-          git clone https://${TOKEN}@github.com/kevinchappell/formBuilder-site.git
-          cd formBuilder-site
-          npm version ${{ env.VERSION }}
-
-          # Commit and push the changes
-          git commit -am "Update site to ${{ env.VERSION }}"
-          git push https://${TOKEN}@github.com/kevinchappell/formBuilder-site.git master


### PR DESCRIPTION
Due to recursion protection GitHub actions does not trigger the publish event when the release is created via another action. Instead use the workflow_run event to chain Publish with Deploy Website