### PR TITLE
Various small cleanups to code

### DIFF
--- a/src/js/control.js
+++ b/src/js/control.js
@@ -119,7 +119,7 @@ export default class control {
 
   /**
    * Looks up the classRegister & returns registered types or subtypes
-   * @param  {String} type optional type of control we want to look up
+   * @param  {string|false} type optional type of control we want to look up
    * subtypes of. If not specified will return all types
    * @return {Array} registered types (or subtypes)
    */
@@ -134,7 +134,7 @@ export default class control {
       if (type) {
         return key.indexOf(type + '.') > -1
       }
-      return key.indexOf('.') == -1
+      return key.indexOf('.') === -1
     })
   }
 
@@ -215,7 +215,7 @@ export default class control {
    * By default looks for translations defined against the class (for plugin controls)
    * Expects {locale1: {type: label}, locale2: {type: label}}, or {default: label}, or {local1: label, local2: label2}
    * @param {String} lookup string to retrieve the label / translated string for
-   * @param {Object|Number|String} args - string or key/val pairs for string lookups with variables
+   * @param {Object|Number|String} [args] - string or key/val pairs for string lookups with variables
    * @return {String} the translated label
    */
   static mi18n(lookup, args) {
@@ -248,7 +248,7 @@ export default class control {
    * @return {Boolean} isActive
    */
   static active(type) {
-    return !Array.isArray(this.definition.inactive) || this.definition.inactive.indexOf(type) == -1
+    return !Array.isArray(this.definition.inactive) || this.definition.inactive.indexOf(type) === -1
   }
 
   /**
@@ -311,7 +311,7 @@ export default class control {
 
       /**
        * onRender event to execute code each time an instance of this control is injected into the DOM
-       * @param {Node} element
+       * @param {Node} evt
        */
       render: evt => {
         // check for a class render event - default to an empty function

--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -9,7 +9,7 @@ export const defaultSubtypes = {
 
 /**
  * Removes a dom node
- * @param  {Object} element
+ * @param {Node} element
  */
 export const remove = element => {
   if (element.parentNode) {
@@ -17,6 +17,12 @@ export const remove = element => {
   }
 }
 
+
+/**
+ * Util to remove contents of DOM Node
+ * @param  {HTMLElement} element
+ * @return {HTMLElement} element with its children removed
+ */
 export const empty = element => {
   while (element.firstChild) {
     element.removeChild(element.firstChild)
@@ -24,6 +30,13 @@ export const empty = element => {
   return element
 }
 
+/**
+ * Hide or show an Array|HTMLCollection of elements containing a case-insensitive string
+ * @param  {HTMLElement[]|HTMLCollection}   elems
+ * @param  {string}  term  match textContent to this term
+ * @param  {boolean} [show=true] show or hide elements
+ * @return {HTMLElement[]}         filtered elements
+ */
 export const filter = (elems, term, show = true) => {
   const filteredElems = []
   let toggle = ['none', 'block']
@@ -53,9 +66,26 @@ export const optionFieldsRegEx = new RegExp(`(${optionFields.join('|')})`)
  */
 export default class Dom {
   /**
+   * @type {HTMLUListElement}
+   */
+  stage
+  /**
+   * @type {HTMLElement}
+   */
+  controls
+  /**
+   * @type {HTMLElement}
+   */
+  formActions
+  /**
+   * @type {HTMLElement}
+   */
+  editorWrap
+
+  /**
    * Set defaults
-   * @param  {String} formID [description]
-   * @return {Object} Dom Instance
+   * @param {string} formID
+   * @return {Dom} Dom Instance
    */
   constructor(formID) {
     this.optionFields = optionFields
@@ -65,17 +95,17 @@ export default class Dom {
 
     /**
      * Util to remove contents of DOM Object
-     * @param  {Object} element
-     * @return {Object} element with its children removed
+     * @param  {HTMLElement} element
+     * @return {HTMLElement} element with its children removed
      */
     this.empty = empty
 
     /**
-     * Hide or show an Array or HTMLCollection of elements
-     * @param  {Array}   elems
-     * @param  {String}  term  match textContent to this term
-     * @param  {Boolean} show  or hide elements
-     * @return {Array}         filtered elements
+     * Hide or show an Array|HTMLCollection of elements containing a case-insensitive string
+     * @param  {HTMLElement[]|HTMLCollection}   elems
+     * @param  {string}  term  match textContent to this term
+     * @param  {boolean} show  or hide elements
+     * @return {HTMLElement[]}         filtered elements
      */
     this.filter = filter
 
@@ -84,9 +114,15 @@ export default class Dom {
   }
 
   /**
+   * @callback onRenderCallback
+   * @param {HTMLElement} evt - rendered node
+   */
+
+  /**
    * Do something when a specific dom element renders
-   * @param {Object} node
-   * @param {Function} cb
+   *
+   * @param {HTMLElement} node
+   * @param {onRenderCallback} cb
    */
   onRender(node, cb) {
     if (!node.parentElement) {

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -2392,13 +2392,7 @@ function FormBuilder(opts, element, $) {
     const $optionWrap = $(e.target).closest('.field-options')
     const $multiple = $('[name="multiple"]', $optionWrap)
     const $firstOption = $('.option-selected:eq(0)', $optionWrap)
-    let isMultiple = false
-
-    if ($multiple.length) {
-      isMultiple = $multiple.prop('checked')
-    } else {
-      isMultiple = $firstOption.attr('type') === 'checkbox'
-    }
+    const isMultiple = ($multiple.length) ? $multiple.prop('checked') : $firstOption.attr('type') === 'checkbox'
 
     const optionTemplate = { selected: false, label: '', value: '' }
     const $sortableOptions = $('.sortable-options', $optionWrap)

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -2425,7 +2425,7 @@ function FormBuilder(opts, element, $) {
   formBuilder.actions = {
     getFieldTypes: activeOnly =>
       activeOnly ? subtract(controls.getRegistered(), opts.disableFields) : controls.getRegistered(),
-    clearFields: animate => h.removeAllFields(d.stage, animate),
+    clearFields: () => h.removeAllFields(d.stage),
     showData: h.showData.bind(h),
     save: minify => {
       const formData = h.save(minify)
@@ -2442,7 +2442,7 @@ function FormBuilder(opts, element, $) {
     getData: h.getFormData.bind(h),
     setData: formData => {
       h.stopIndex = undefined
-      h.removeAllFields(d.stage, false)
+      h.removeAllFields(d.stage)
       loadFields(formData)
     },
     setLang: locale => {

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1150,7 +1150,7 @@ export default class Helpers {
 
   /**
    * Generate stage and controls dom elements
-   * @param  {String} formID [description]
+   * @param  {string} formID
    */
   editorUI(formID) {
     const d = this.d

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -504,8 +504,8 @@ export default class Helpers {
   /**
    * Closes and open dialog
    *
-   * @param  {Object} [overlay] Existing overlay if there is one
-   * @param  {Object} [dialog]  Existing dialog
+   * @param  {HTMLElement} [overlay] Existing overlay if there is one
+   * @param  {HTMLElement} [dialog]  Existing dialog
    */
   closeConfirm(overlay, dialog) {
     if (!overlay) {
@@ -522,8 +522,7 @@ export default class Helpers {
 
   /**
    *
-   * @param {Object} e keydown event object
-   * @param {Function} cb callback
+   * @param {KeyboardEvent} e keydown event object
    */
   handleKeyDown(e) {
     const keyCode = e.keyCode || e.which

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -325,15 +325,15 @@ export default class Helpers {
 
   /**
    * Saves and returns formData
-   * @param {Boolean} minify whether to return formatted or minified data
-   * @return {XML|JSON} formData
+   * @param {boolean} [minify=false] whether to return formatted or minified data
+   * @return {string} formData FormData formatted in either XML or JSON depending on the current config.opts.dataType value
    */
-  save(minify) {
+  save(minify = false) {
     const _this = this
     const data = this.data
     const stage = this.d.stage
     const doSave = {
-      xml: minify => _this.xmlSave(stage, minify),
+      xml: () => _this.xmlSave(stage),
       json: minify => window.JSON.stringify(_this.prepData(stage), null, minify && '  '),
     }
 

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -369,7 +369,7 @@ export default class Helpers {
     forEach(attrs, index => {
       const attr = attrs[index]
       const name = camelCase(attr.getAttribute('name'))
-      const value = [
+      fieldData[name] = [
         [
           attr.attributes.contenteditable,
           () => (config.opts.dataType === 'xml' ? escapeHtml(attr.innerHTML) : attr.innerHTML),
@@ -379,7 +379,6 @@ export default class Helpers {
         [attr.attributes.multiple, () => $(attr).val()],
         [true, () => attr.value],
       ].find(([condition]) => !!condition)[1]()
-      fieldData[name] = value
     })
     return fieldData
   }

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -504,8 +504,8 @@ export default class Helpers {
   /**
    * Closes and open dialog
    *
-   * @param  {Object} overlay Existing overlay if there is one
-   * @param  {Object} dialog  Existing dialog
+   * @param  {Object} [overlay] Existing overlay if there is one
+   * @param  {Object} [dialog]  Existing dialog
    */
   closeConfirm(overlay, dialog) {
     if (!overlay) {

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -708,8 +708,7 @@ export default class Helpers {
 
   /**
    * Removes all fields from the form
-   * @param {Object} stage to remove fields form
-   * @param {Boolean} animate whether to animate or not
+   * @param {HTMLElement} stage to remove fields form
    * @return {void}
    */
   removeAllFields(stage) {
@@ -719,7 +718,7 @@ export default class Helpers {
     const markEmptyArray = []
 
     if (!fields.length) {
-      return false
+      return
     }
 
     if (opts.prepend) {

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -460,7 +460,7 @@ export default class Helpers {
    * Process classNames for field
    * @param  {Object} field
    * @param  {Object} previewData
-   * @return {String} classNames
+   * @return {String|void} classNames
    */
   classNames(field, previewData) {
     const className = field.querySelector('.fld-className')
@@ -626,7 +626,7 @@ export default class Helpers {
 
   /**
    * Popup dialog the does not require confirmation.
-   * @param  {String|DOM|Array}  content
+   * @param  {String|HTMLElement|Array}  content
    * @param  {Boolean} coords    screen coordinates to position dialog
    * @param  {String}  className classname to be added to the dialog
    * @return {Object}            dom

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -96,10 +96,10 @@ export default class layout {
    *   - field - the DOM element
    *   - noLabel - this control shouldn't have a label (nor a space for a label)
    *   - hidden - this control shouldn't render anything visible to the page
-   * @param {Object} renderControl - the relevant control class
+   * @param {Class} renderControl - the relevant control class
    * @param {Object} data - configuration data passed through formData for this control
-   * @param {String} forceTemplate - programatically force the template with which this control to be rendered
-   * @return {Object} element
+   * @param {String} forceTemplate - programmatically force the template with which this control to be rendered
+   * @return {HTMLElement} element
    */
   build(renderControl, data, forceTemplate) {
     // prepare the data
@@ -199,7 +199,7 @@ export default class layout {
    * Process a template & prepare the results
    * @param {String} template - template key to execute
    * @param {Array} args - any number of args that should be passed to the template. this.data is sent as the last parameter to any template.
-   * @return {DOMElement}
+   * @return {HTMLElement}
    */
   processTemplate(template, ...args) {
     let processed = this.templates[template](...args, this.data)

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -431,7 +431,7 @@ export const removeFromArray = (val, arr) => {
 /**
  * Loads an array of scripts using jQuery's `getScript`
  * @param  {Array|String}  scriptScr    scripts
- * @param  {String} path   optional to load form
+ * @param  {String} [path='']   optional to load form
  * @return {Promise}       a promise
  */
 export const getScripts = (scriptScr, path) => {
@@ -478,7 +478,7 @@ export const isCached = (src, type = 'js') => {
 /**
  * Appends stylesheets to the head
  * @param  {Array} scriptScr
- * @param  {String} path
+ * @param  {String} [path='']
  * @return {void}
  */
 export const getStyles = (scriptScr, path) => {
@@ -496,7 +496,7 @@ export const getStyles = (scriptScr, path) => {
       type = src.type || (src.style ? 'inline' : 'href')
       id = src.id
       key = id || src.href || src.style
-      src = type == 'inline' ? src.style : src.href
+      src = type === 'inline' ? src.style : src.href
     }
 
     // check we haven't already loaded this css
@@ -505,7 +505,7 @@ export const getStyles = (scriptScr, path) => {
     }
 
     // append the style into the head
-    if (type == 'href') {
+    if (type === 'href') {
       const link = document.createElement('link')
       link.type = 'text/css'
       link.rel = 'stylesheet'


### PR DESCRIPTION
@kevinchappell There are a bunch of little cleanups in this PR that I've been keeping in the testing framework branch but should be applied now rather than with that PR. There are no functionality changes with this.

Main items: 
- Remove calling clearAllFields with an animate flag, flag was removed in https://github.com/lucasnetau/formBuilder/commit/753280f183663dd153802458209b6427c10f4c36
- xmlSave does not support minify, don't call xmlSave with a minify flag set
- Various function parameters not marked as optional
- JSDoc cleanup, the majority of these JSDoc cleanup is to ensure we have the correct definition of the function and ensure that when we are testing it we can test against that contract. 