### PR TITLE
fix: correct the documentation for formRender action clear()

### DIFF
--- a/docs/formRender/actions/clear.md
+++ b/docs/formRender/actions/clear.md
@@ -11,5 +11,7 @@ const html = formRenderInstance('html'); // HTML DOM nodes
 const htmlString = html.outerHTML;
 </code></pre>
 // User enters data
-<pre><code class="js">formRenderInstance('clear');</code></pre>
+<pre><code class="js">formRenderInstance.clear();
+// or
+$('#render-container').formRender('clear')</code></pre>
 // User entered data is cleared


### PR DESCRIPTION
Documentation uses incorrect example formRenderInstance('clear') which throws a TypeError (formRenderInstance is not a function)

Fixes #1371