### PR TITLE
Escape formData in showData dialog for all dataTypes

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -988,11 +988,7 @@ export default class Helpers {
    * Open a dialog with the form's data
    */
   showData() {
-    let formData = this.getFormData(config.opts.dataType, true)
-
-    if (config.opts.dataType === 'xml') {
-      formData = escapeHtml(formData)
-    }
+    const formData = escapeHtml(this.getFormData(config.opts.dataType, true))
 
     const code = m('code', formData, {
       className: `formData-${config.opts.dataType}`,


### PR DESCRIPTION
formData may contain HTML (eg Labels), need to escape for all dataTypes before adding into the code element, not just for XML datatype

JSON is invalid if copy-paste from showData dialog:

```javascript
       {
           "type": "text",
           "required": false,
           "label": "Item<br>Label",
           "className": "form-control",
       },
```

would be rendered as

```javascript
       {
           "type": "text",
           "required": false,
           "label": "Item
Label",
           "className": "form-control",
       },
```