### PR TITLE
Refactor CSS to fix various namespace clashes and improve compatibility with newer Bootstrap CSS libraries

### DIFF
--- a/docs/formBuilder/options/disableInjectedStyle.md
+++ b/docs/formBuilder/options/disableInjectedStyle.md
@@ -1,7 +1,19 @@
 # disableInjectedStyle
-I'm not sure why anyone would want to do this but it's been requested a couple times so here it is... `disableInjectedStyle` enables you to disabled the injeted style that ships with the plugin.
 
-## Usage
+FormBuilder ships with a minimal Bootstrap 3 set of CSS classes for rendering form controls. You may choose to disable these to ensure they do not clash with a Bootstrap 4 or 5 included stylesheet
+
+## Disable Embedded Bootstrap Classes
+```javascript
+var options = {
+  disableInjectedStyle: "bootstrap"
+};
+$(container).formBuilder(options);
+```
+
+## Disable all embedded styles
+
+You can also completely disable all embedded styles, I'm not sure why anyone would want to do this, but it's been requested a couple of times so here it is... `disableInjectedStyle` enables you to disable the injected style that ships with the plugin.
+
 ```javascript
 var options = {
   disableInjectedStyle: true

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -2414,9 +2414,11 @@ function FormBuilder(opts, element, $) {
 
   loadFields()
 
-  if (opts.disableInjectedStyle) {
+  if (opts.disableInjectedStyle === true) {
     const styleTags = document.getElementsByClassName('formBuilder-injected-style')
     forEach(styleTags, i => remove(styleTags[i]))
+  } else if (opts.disableInjectedStyle === 'bootstrap') {
+    d.editorWrap.classList.remove('formbuilder-embedded-bootstrap')
   }
 
   document.dispatchEvent(events.loaded)

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -87,7 +87,7 @@ class FormRender {
           fields = [fields]
         }
         const renderedFormWrap = utils.markup('div', fields, {
-          className: 'rendered-form',
+          className: 'rendered-form formbuilder-embedded-bootstrap',
         })
         this.appendChild(renderedFormWrap)
 
@@ -228,9 +228,11 @@ class FormRender {
       opts.notify.error(opts.messages.noFormData)
     }
 
-    if (opts.disableInjectedStyle) {
+    if (opts.disableInjectedStyle === true) {
       const styleTags = document.getElementsByClassName('formBuilder-injected-style')
       forEach(styleTags, i => remove(styleTags[i]))
+    } else if (opts.disableInjectedStyle === 'bootstrap' && opts.render && element) {
+      element.getElementsByClassName('formbuilder-embedded-bootstrap').item(0)?.classList.remove('formbuilder-embedded-bootstrap')
     }
     return formRender
   }

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1161,7 +1161,7 @@ export default class Helpers {
 
     d.editorWrap = m('div', null, {
       id: `${data.formID}-form-wrap`,
-      className: `form-wrap form-builder ${mobileClass()}`,
+      className: `form-wrap form-builder formbuilder-embedded-bootstrap ${mobileClass()}`,
     })
 
     d.stage = m('ul', null, {

--- a/src/sass/_stage.scss
+++ b/src/sass/_stage.scss
@@ -688,56 +688,6 @@
   }
 }
 
-/*   ------------   TOOLTIP   ------------   */
-
-*[tooltip] {
-  position: relative;
-}
-
-*[tooltip]:hover:after {
-  background: rgba(0, 0, 0, 0.9);
-  border-radius: 5px 5px 5px 0;
-  bottom: 23px;
-  color: $white;
-  content: attr(tooltip);
-  padding: 10px 5px;
-  position: absolute;
-  z-index: 98;
-  left: 2px;
-  width: 230px;
-  text-shadow: none;
-  font-size: 12px;
-  line-height: 1.5em;
-  cursor: default;
-}
-
-*[tooltip]:hover:before {
-  border: solid;
-  border-color: $grey-dark transparent;
-  border-width: 6px 6px 0;
-  bottom: 17px;
-  content: '';
-  left: 2px;
-  position: absolute;
-  z-index: 99;
-  cursor: default;
-}
-
-.tooltip-element {
-  visibility: visible;
-  color: $white;
-  background: $black;
-  width: 16px;
-  height: 16px;
-  border-radius: 8px;
-  display: inline-block;
-  text-align: center;
-  line-height: 16px;
-  margin: 0 5px;
-  font-size: 12px;
-  cursor: default;
-}
-
 /*   ------------   Toast Message   ------------   */
 .snackbar {
   visibility: hidden; /* Hidden by default. Visible on click */

--- a/src/sass/_stage.scss
+++ b/src/sass/_stage.scss
@@ -370,8 +370,13 @@
 
     .toggle-form {
       &:hover {
+        border-color: lighten($grey, 40%);
         background-color: $edit;
         color: $white;
+      }
+
+      &::before {
+        margin: 0;
       }
     }
 

--- a/src/sass/_tooltip.scss
+++ b/src/sass/_tooltip.scss
@@ -1,0 +1,48 @@
+// TOOLTIP   ------------
+*[tooltip] {
+  position: relative;
+}
+
+*[tooltip]:hover::after {
+  background: rgba(0, 0, 0, 0.9);
+  border-radius: 5px 5px 5px 0;
+  bottom: 23px;
+  color: $white;
+  content: attr(tooltip);
+  padding: 10px 5px;
+  position: absolute;
+  z-index: 98;
+  left: 2px;
+  width: 230px;
+  text-shadow: none;
+  font-size: 12px;
+  line-height: 1.5em;
+  cursor: default;
+}
+
+*[tooltip]:hover::before {
+  border: solid;
+  border-color: $grey-dark transparent;
+  border-width: 6px 6px 0;
+  bottom: 17px;
+  content: '';
+  left: 2px;
+  position: absolute;
+  z-index: 99;
+  cursor: default;
+}
+
+.tooltip-element {
+  visibility: visible;
+  color: $white;
+  background: $black;
+  width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  display: inline-block;
+  text-align: center;
+  line-height: 16px;
+  margin: 0 5px;
+  font-size: 12px;
+  cursor: default;
+}

--- a/src/sass/base/_bs.scss
+++ b/src/sass/base/_bs.scss
@@ -1,8 +1,4 @@
 // Minimal Bootstrap
-* {
-  box-sizing: border-box;
-}
-
 button,
 input,
 select,
@@ -202,61 +198,4 @@ textarea.form-control {
 
 .pull-left {
   float: left;
-}
-
-.formbuilder-required,
-.required-asterisk {
-  color: $error;
-}
-
-.formbuilder-checkbox-group,
-.formbuilder-radio-group {
-  input[type='checkbox'],
-  input[type='radio'] {
-    margin: 0 4px 0 0;
-  }
-}
-
-.formbuilder-checkbox-inline,
-.formbuilder-radio-inline {
-  margin-right: 8px;
-  display: inline-block;
-  vertical-align: middle;
-  padding-left: 0;
-  label {
-    input[type='text'] {
-      margin-top: 0;
-    }
-  }
-}
-
-.formbuilder-checkbox-inline:first-child,
-.formbuilder-radio-inline:first-child {
-  padding-left: 0;
-}
-
-.formbuilder-autocomplete-list {
-  background-color: $white;
-  display: none;
-  list-style: none;
-  padding: 0;
-  border: 1px solid $grey-light;
-  border-width: 0 1px 1px;
-  position: absolute;
-  z-index: 20;
-  max-height: 200px;
-  overflow-y: auto;
-
-  li {
-    display: none;
-    cursor: default;
-    padding: 5px;
-    margin: 0;
-    transition: background-color 200ms ease-in-out;
-
-    &:hover,
-    &.active-option {
-      background-color: $input-box-shadow-color;
-    }
-  }
 }

--- a/src/sass/base/_fields.scss
+++ b/src/sass/base/_fields.scss
@@ -1,0 +1,56 @@
+.formbuilder-required,
+.required-asterisk {
+  color: $error;
+}
+
+.formbuilder-checkbox-group,
+.formbuilder-radio-group {
+  input[type='checkbox'],
+  input[type='radio'] {
+    margin: 0 4px 0 0;
+  }
+}
+
+.formbuilder-checkbox-inline,
+.formbuilder-radio-inline {
+  margin-right: 8px;
+  display: inline-block;
+  vertical-align: middle;
+  padding-left: 0;
+  label {
+    input[type='text'] {
+      margin-top: 0;
+    }
+  }
+}
+
+.formbuilder-checkbox-inline:first-child,
+.formbuilder-radio-inline:first-child {
+  padding-left: 0;
+}
+
+.formbuilder-autocomplete-list {
+  background-color: $white;
+  display: none;
+  list-style: none;
+  padding: 0;
+  border: 1px solid $grey-light;
+  border-width: 0 1px 1px;
+  position: absolute;
+  z-index: 20;
+  max-height: 200px;
+  overflow-y: auto;
+
+  li {
+    display: none;
+    cursor: default;
+    padding: 5px;
+    margin: 0;
+    transition: background-color 200ms ease-in-out;
+
+    &:hover,
+    &.active-option {
+      background-color: $input-box-shadow-color;
+    }
+  }
+}

--- a/src/sass/form-builder.scss
+++ b/src/sass/form-builder.scss
@@ -3,7 +3,14 @@
 @import 'base/mixins';
 
 .form-wrap.form-builder {
-  @import 'base/bs';
+  * {
+    box-sizing: border-box;
+  }
+
+  &.formbuilder-embedded-bootstrap {
+    @import 'base/bs';
+  }
+  @import 'base/fields';
   @import 'base/animation';
   @import 'controls';
   @import 'stage';

--- a/src/sass/form-builder.scss
+++ b/src/sass/form-builder.scss
@@ -16,104 +16,82 @@
     display: table;
     clear: both;
   }
-}
 
-.cb-wrap,
-.stage-wrap {
-  vertical-align: top;
+  .cb-wrap,
+  .stage-wrap {
+    vertical-align: top;
 
-  &.pull-right {
-    float: right;
-  }
+    &.pull-right {
+      float: right;
+    }
 
-  &.pull-left {
-    float: left;
-  }
-}
-
-.form-elements,
-.form-group,
-.multi-row span,
-textarea {
-  display: block;
-}
-
-.form-elements::after,
-.form-group::after {
-  content: '.';
-  display: block;
-  height: 0;
-  clear: both;
-  visibility: hidden;
-}
-
-.form-elements .field-options div:hover,
-.frmb .legend,
-.frmb .prev-holder {
-  cursor: move;
-}
-
-// tooltips
-.frmb-tt {
-  display: none;
-  position: absolute;
-  top: 0;
-  left: 0;
-  border: 1px solid darken($grey, 25%);
-  background-color: $grey;
-  border-radius: 5px;
-  padding: 5px;
-  color: $white;
-  z-index: 20;
-  text-align: left;
-  font-size: 12px;
-  pointer-events: none;
-
-  &::before {
-    border-color: darken($grey, 25%) transparent;
-    bottom: -11px;
-  }
-
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    border-style: solid;
-    border-width: 10px 10px 0;
-    border-color: $grey transparent;
-    display: block;
-    width: 0;
-    z-index: 1;
-    margin-left: -10px;
-    bottom: -10px;
-    left: 20px;
-  }
-
-  a {
-    text-decoration: underline;
-    color: $white;
-  }
-}
-
-.frmb li {
-  &:hover,
-  .formbuilder-mobile & {
-    .del-button,
-    .toggle-form {
-      opacity: 1;
+    &.pull-left {
+      float: left;
     }
   }
-}
 
-.toggle-form {
-  opacity: 0;
-
-  &:hover {
-    border-color: lighten($grey, 40%);
+  .form-elements,
+  .form-group,
+  .multi-row span,
+  textarea {
+    display: block;
   }
 
-  &::before {
-    margin: 0;
+  .form-elements::after,
+  .form-group::after {
+    content: '.';
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden;
+  }
+
+  .form-elements .field-options div:hover,
+  .frmb .legend,
+  .frmb .prev-holder {
+    cursor: move;
+  }
+
+  // tooltips
+  .frmb-tt {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    border: 1px solid darken($grey, 25%);
+    background-color: $grey;
+    border-radius: 5px;
+    padding: 5px;
+    color: $white;
+    z-index: 20;
+    text-align: left;
+    font-size: 12px;
+    pointer-events: none;
+
+    &::before {
+      border-color: darken($grey, 25%) transparent;
+      bottom: -11px;
+    }
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      border-style: solid;
+      border-width: 10px 10px 0;
+      border-color: $grey transparent;
+      display: block;
+      width: 0;
+      z-index: 1;
+      margin-left: -10px;
+      bottom: -10px;
+      left: 20px;
+    }
+
+    a {
+      text-decoration: underline;
+      color: $white;
+    }
   }
 }
 

--- a/src/sass/form-builder.scss
+++ b/src/sass/form-builder.scss
@@ -7,6 +7,7 @@
   @import 'base/animation';
   @import 'controls';
   @import 'stage';
+  @import 'tooltip';
   @import 'kc-toggle';
   position: relative;
 

--- a/src/sass/form-render.scss
+++ b/src/sass/form-render.scss
@@ -1,7 +1,14 @@
 @import 'base/variables';
 
 .rendered-form {
-  @import 'base/bs';
+  * {
+    box-sizing: border-box;
+  }
+
+  &.formbuilder-embedded-bootstrap {
+    @import 'base/bs';
+  }
+  @import 'base/fields';
   @import 'tooltip';
   @import 'kc-toggle';
 

--- a/src/sass/form-render.scss
+++ b/src/sass/form-render.scss
@@ -8,35 +8,35 @@
   label {
     font-weight: normal;
   }
-}
 
-.form-group .formbuilder-required {
-  color: $error;
-}
-
-.other-option:checked + label {
-  input {
-    display: inline-block;
-  }
-}
-
-.other-val {
-  margin-left: 5px;
-  display: none;
-}
-
-.form-control {
-  &.number {
-    width: auto;
+  .form-group .formbuilder-required {
+    color: $error;
   }
 
-  &[type='color'] {
-    width: 60px;
-    padding: 2px;
-    display: inline-block;
+  .other-option:checked + label {
+    input {
+      display: inline-block;
+    }
   }
 
-  &[multiple] {
-    height: auto;
+  .other-val {
+    margin-left: 5px;
+    display: none;
+  }
+
+  .form-control {
+    &.number {
+      width: auto;
+    }
+
+    &[type='color'] {
+      width: 60px;
+      padding: 2px;
+      display: inline-block;
+    }
+
+    &[multiple] {
+      height: auto;
+    }
   }
 }

--- a/src/sass/form-render.scss
+++ b/src/sass/form-render.scss
@@ -1,8 +1,8 @@
 @import 'base/variables';
 
-
 .rendered-form {
   @import 'base/bs';
+  @import 'tooltip';
   @import 'kc-toggle';
 
   label {
@@ -23,51 +23,6 @@
 .other-val {
   margin-left: 5px;
   display: none;
-}
-
-// TOOLTIP   ------------
-*[tooltip] {
-  position: relative;
-}
-
-*[tooltip]:hover::after {
-  background: rgba(0, 0, 0, 0.9);
-  border-radius: 5px 5px 5px 0;
-  bottom: 23px;
-  color: $white;
-  content: attr(tooltip);
-  padding: 10px 5px;
-  position: absolute;
-  z-index: 98;
-  left: 2px;
-  width: 230px;
-  text-shadow: none;
-  font-size: 12px;
-  line-height: 1.5em;
-}
-
-*[tooltip]:hover::before {
-  border: solid;
-  border-color: #222 transparent;
-  border-width: 6px 6px 0;
-  bottom: 17px;
-  content: '';
-  left: 2px;
-  position: absolute;
-  z-index: 99;
-}
-
-.tooltip-element {
-  color: $white;
-  background: $black;
-  width: 16px;
-  height: 16px;
-  border-radius: 8px;
-  display: inline-block;
-  text-align: center;
-  line-height: 16px;
-  margin: 0 5px;
-  font-size: 12px;
 }
 
 .form-control {


### PR DESCRIPTION
FormBuilder has an embedded Bootstrap 3 stylesheet which can cause clashes with HTML elements outside of the formBuilder and formRender containers.

This PR does some refactoring of the style and introduces a modification to an option flag to selectively disable Bootstrap 3 styles into the form.

Refactoring: Move classes under the .rendered-form and .form-wrap.form-builder containers. This ensures we are only setting styles for Elements within our container.

Fixes #594
Fixes #727 

Refactoring: Tooltips styles de-duplicated and moved under their own includable scss file to share between form-render and form-builder

Feat: By moving the embedding of Bootstrap 3 styles under an enabling class .formbuilder-embedded-bootstrap we can selectively disable those styles by removing that class. This can be done by setting `disableInjectedStyle` to `'bootstrap'`, effectively changing `disableInjectedStyle` from a boolean to a boolean|string option. As disableInjectedStyle defaults to false, the Bootstrap classes will be embedded

Testing has shown no oddities on either Builder nor Render.



