### PR TITLE
Replace deprecated function calls

### DIFF
--- a/src/js/control_plugins/starRating.js
+++ b/src/js/control_plugins/starRating.js
@@ -7,11 +7,12 @@ if (!window.fbControls) window.fbControls = []
 window.fbControls.push(function(controlClass) {
   /**
    * Star rating class
+   * @extends control
    */
   class controlStarRating extends controlClass {
     /**
      * Class configuration - return the icons & label related to this control
-     * @returndefinition object
+     * @return {Object} definition object
      */
     static get definition() {
       return {
@@ -32,10 +33,11 @@ window.fbControls.push(function(controlClass) {
 
     /**
      * build a text DOM element, supporting other jquery text form-control's
-     * @return {Object} DOM Element to be injected into the form.
+     * @return {HTMLElement} DOM Element to be injected into the form.
      */
     build() {
-      return this.markup('span', null, { id: this.config.name })
+      this.dom = this.markup('span', null, { id: this.config.name })
+      return this.dom
     }
 
     /**
@@ -43,7 +45,7 @@ window.fbControls.push(function(controlClass) {
      */
     onRender() {
       const value = this.config.value || 3.6
-      $('#' + this.config.name).rateYo({ rating: value })
+      $(this.dom).rateYo({ rating: value })
     }
   }
 

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -57,8 +57,8 @@ export default class Controls {
     if (customFields) {
       jQuery.merge(registeredControls, customFields)
     }
-    const registeredSubtypes = control.getRegisteredSubtypes()
-    this.registeredSubtypes = registeredSubtypes
+
+    this.registeredSubtypes = control.getRegisteredSubtypes()
 
     // if we support rearranging control order, add classes to support this
     if (opts.sortableControls) {

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -55,7 +55,7 @@ let isMoving = false
 function FormBuilder(opts, element, $) {
   const formBuilder = this
   const i18n = mi18n.current
-  const formID = `frmb-${new Date().getTime()}`
+  const formID = `frmb-${Date.now()}`
   const data = new Data(formID)
   const d = new Dom(formID)
 

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1324,7 +1324,7 @@ export default class Helpers {
 
   //Remove one reference that protected this potentially empty container. There may be other open fields needing the container
   removeContainerProtection(containerID) {
-    var index = this.formBuilder.preserveTempContainers.indexOf(containerID)
+    const index = this.formBuilder.preserveTempContainers.indexOf(containerID)
     if (index !== -1) {
       this.formBuilder.preserveTempContainers.splice(index, 1)
     }

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -769,7 +769,6 @@ export default class Helpers {
 
   /**
    * Close fields being editing
-   * @param  {Object} stage
    */
   closeAllEdit() {
     const _this = this

--- a/src/js/sanitizer.js
+++ b/src/js/sanitizer.js
@@ -200,6 +200,7 @@ const sanitizersCallbacks = {
     const sanitizer = sanitizerConfig.backends.sanitizer
     if (sanitizer) {
       element.setHTML(content, { sanitizer: sanitizer })
+      return true
     }
     return false
   }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -758,11 +758,11 @@ utils.splitObject = (obj, keys) => {
 }
 
 $.fn.swapWith = function (that) {
-  var $this = this
-  var $that = $(that)
+  const $this = this
+  const $that = $(that)
 
   // create temporary placeholder
-  var $temp = $('<div>')
+  const $temp = $('<div>')
 
   // 3-step swap
   $this.before($temp)

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -274,10 +274,10 @@ export const markup = function (tag, content = '', attributes = {}) {
 
 /**
  * Convert html element attributes to key/value object
- * @param  {Object} elem DOM element
+ * @param  {Element} elem DOM element
  * @return {Object} ex: {attrName: attrValue}
  */
-export const parseAttrs = elem => {
+export const xmlParseAttrs = elem => {
   const attrs = elem.attributes
   const data = {}
   forEach(attrs, attr => {
@@ -301,12 +301,12 @@ export const parseAttrs = elem => {
  * @param  {NodeList} options  DOM elements
  * @return {Array} optionData array
  */
-export const parseOptions = options => {
+export const xmlParseOptions = options => {
   const data = []
 
   for (let i = 0; i < options.length; i++) {
     const optionData = {
-      ...parseAttrs(options[i]),
+      ...xmlParseAttrs(options[i]),
       label: options[i].textContent,
     }
     data.push(optionData)
@@ -320,7 +320,7 @@ export const parseOptions = options => {
  * @param  {NodeList} userData  DOM elements
  * @return {Array} optionData array
  */
-export const parseUserData = userData => {
+export const xmlParseUserData = userData => {
   const data = []
 
   if (userData.length) {
@@ -336,7 +336,7 @@ export const parseUserData = userData => {
 
 /**
  * Parse XML formData
- * @param  {String} xmlString
+ * @param  {string} xmlString
  * @return {Array}            formData array
  */
 export const parseXML = xmlString => {
@@ -347,16 +347,16 @@ export const parseXML = xmlString => {
   if (xml) {
     const fields = xml.getElementsByTagName('field')
     for (let i = 0; i < fields.length; i++) {
-      const fieldData = parseAttrs(fields[i])
+      const fieldData = xmlParseAttrs(fields[i])
       const options = fields[i].getElementsByTagName('option')
       const userData = fields[i].getElementsByTagName('userData')
 
       if (options && options.length) {
-        fieldData.values = parseOptions(options)
+        fieldData.values = xmlParseOptions(options)
       }
 
       if (userData && userData.length) {
-        fieldData.userData = parseUserData(userData)
+        fieldData.userData = xmlParseUserData(userData)
       }
 
       formData.push(fieldData)
@@ -715,10 +715,7 @@ const utils = {
   merge,
   mobileClass,
   nameAttr,
-  parseAttrs,
   parsedHtml,
-  parseOptions,
-  parseUserData,
   parseXML,
   removeFromArray,
   safeAttr,
@@ -729,6 +726,9 @@ const utils = {
   unique,
   validAttr,
   titleCase,
+  xmlParseAttrs,
+  xmlParseOptions,
+  xmlParseUserData,
 }
 
 /**

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -691,7 +691,7 @@ export function titleCase(str) {
   const regex = new RegExp(`(?!${lowers.join('|')})\\w\\S*`, 'g')
   return `${str}`.replace(
     regex,
-    txt => txt.charAt(0).toUpperCase() + txt.substr(1).replace(/[A-Z]/g, word => ` ${word}`),
+    txt => txt.charAt(0).toUpperCase() + txt.slice(1).replace(/[A-Z]/g, word => ` ${word}`),
   )
 }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -249,7 +249,7 @@ export const markup = function (tag, content = '', attributes = {}) {
       }
       if (typeof attrVal === 'boolean') {
         if (attrVal === true) {
-          const val = name !== 'contenteditable' ? name : true
+          const val = name === 'contenteditable' ? true : name
           field.setAttribute(name, val)
         }
       } else {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -274,6 +274,7 @@ export const markup = function (tag, content = '', attributes = {}) {
 
 /**
  * Convert html element attributes to key/value object
+ * @private
  * @param  {Element} elem DOM element
  * @return {Object} ex: {attrName: attrValue}
  */
@@ -298,6 +299,7 @@ export const xmlParseAttrs = elem => {
 
 /**
  * Convert field options to optionData
+ * @private
  * @param  {NodeList} options  DOM elements
  * @return {Array} optionData array
  */
@@ -317,6 +319,7 @@ export const xmlParseOptions = options => {
 
 /**
  * Convert field user data to userData
+ * @private
  * @param  {NodeList} userData  DOM elements
  * @return {Array} optionData array
  */
@@ -726,9 +729,6 @@ const utils = {
   unique,
   validAttr,
   titleCase,
-  xmlParseAttrs,
-  xmlParseOptions,
-  xmlParseUserData,
 }
 
 /**


### PR DESCRIPTION
A few small fixes bunched together

* Replace deprecated calls to substr and assigning variables by var
* Helper functions for parseXML have been prefixed by xml to make their usage clear
* Apply fix to starRating that was applied to other controls to ensure they can be rendered even if not attached to the DOM