### PR TITLE
Complete implementation of starRating

### DIFF
--- a/src/js/control_plugins/starRating.js
+++ b/src/js/control_plugins/starRating.js
@@ -27,25 +27,32 @@ window.fbControls.push(function(controlClass) {
      * javascript & css to load
      */
     configure() {
-      this.js = '//cdnjs.cloudflare.com/ajax/libs/rateYo/2.2.0/jquery.rateyo.min.js'
-      this.css = '//cdnjs.cloudflare.com/ajax/libs/rateYo/2.2.0/jquery.rateyo.min.css'
+      this.js = 'https://cdnjs.cloudflare.com/ajax/libs/rateYo/2.3.2/jquery.rateyo.min.js'
+      this.css = 'https://cdnjs.cloudflare.com/ajax/libs/rateYo/2.3.2/jquery.rateyo.min.css'
     }
 
     /**
      * build a text DOM element, supporting other jquery text form-control's
-     * @return {HTMLElement} DOM Element to be injected into the form.
+     * @return {HTMLElement|Object|HTMLElement[]} DOM Element to be injected into the form.
      */
     build() {
-      this.dom = this.markup('span', null, { id: this.config.name })
-      return this.dom
+      this.input = this.markup('input', null, { ...this.config, type: 'hidden', })
+      this.field = this.markup('span')
+      return [this.input, this.field]
     }
 
     /**
      * onRender callback
      */
     onRender() {
-      const value = this.config.value || 3.6
-      $(this.dom).rateYo({ rating: value })
+      const value = this.config.userData ? this.config.userData[0] : this.config.value || 3.6
+      const input = $(this.input)
+      $(this.field).rateYo({
+        rating: value,
+        onSet: function(rating) {
+          input.val(rating)
+        }
+      })
     }
   }
 

--- a/tests/control/control_plugin.test.js
+++ b/tests/control/control_plugin.test.js
@@ -27,8 +27,10 @@ describe('Test Custom Control', () => {
     expect(typeof controlInstance).toBe('object')
     expect(controlInstance.constructor.name).toBe('controlStarRating')
 
-    const element = controlInstance.build()
-    expect(element.constructor.name).toBe('HTMLSpanElement')
+    const controlBuild = controlInstance.build()
+    const element = controlBuild[0]
+    expect(element.constructor.name).toBe('HTMLInputElement')
     expect(element.id).toBe('star-1492424082853')
+    expect(element.type).toBe('hidden')
   })
 })


### PR DESCRIPTION
starRating plugin did not have the logic to load userData into the control, nor did it save the rating anywhere for getUserData to retrieve. This PR completes the implementation of starRating

Fixes: #962

@kevinchappell Was starRating meant to be implemented in this way as an example or was this an oversight?