### PR TITLE
feat: Support typeUserAttrs and typeUserEvents for all types with a wildcard config key

### DIFF
--- a/docs/formBuilder/options/typeUserAttrs.md
+++ b/docs/formBuilder/options/typeUserAttrs.md
@@ -64,5 +64,17 @@ const typeUserAttrs = {
 };
 ```
 
+## Example Input for all types
+```javascript
+const typeUserAttrs = {
+  '*': {
+    title: {
+      label: 'Title',
+      value: 'Field Title',
+    }
+  }
+};
+```
+
 ### Usage
 <p data-height="525" data-embed-version="2" data-theme-id="22927" data-slug-hash="yaJbZZ" data-default-tab="js,result" data-user="kevinchappell" class="codepen"></p>

--- a/docs/formBuilder/options/typeUserEvents.md
+++ b/docs/formBuilder/options/typeUserEvents.md
@@ -1,6 +1,10 @@
 # typeUserEvents
 Add functionality to existing and custom attributes using `onclone` and `onadd` events. Events return JavaScript DOM elements.
 
+For all types the wildcard type **_*_** exists.
+
+`onremove` event exists for removal events
+
 ## Usage
 ```javascript
 var options = {
@@ -14,6 +18,11 @@ var options = {
     }
   },
   typeUserEvents: {
+    '*': {
+      onclone: (fld) => {
+        console.log('field cloned');
+      }
+    },
     text: {
       onadd: function(fld) {
         var $patternField = $('.fld-pattern', fld);

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
   "jest": {
     "collectCoverage": true,
     "coverageDirectory": ".jest/coverage",
+    "coveragePathIgnorePatterns": [ "tests/" ],
     "testEnvironment": "jsdom",
     "setupFiles": [
       "./tests/setup-jest.js"

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -608,6 +608,8 @@ function FormBuilder(opts, element, $) {
 
     const noDisable = ['name', 'className']
 
+    const typeUserAttrs = Object.assign({}, opts.typeUserAttrs['*'], opts.typeUserAttrs[type])
+
     Object.keys(fieldAttrs).forEach(index => {
       const attr = fieldAttrs[index]
       const useDefaultAttr = [true]
@@ -623,8 +625,8 @@ function FormBuilder(opts, element, $) {
         useDefaultAttr.push(!userAttrs.includes(attr))
       }
 
-      if (opts.typeUserAttrs[type]) {
-        const userAttrs = Object.keys(opts.typeUserAttrs[type])
+      if (typeUserAttrs) {
+        const userAttrs = Object.keys(typeUserAttrs)
         useDefaultAttr.push(!userAttrs.includes(attr))
       }
 
@@ -644,8 +646,8 @@ function FormBuilder(opts, element, $) {
     }
 
     // Append custom attributes as defined in typeUserAttrs option
-    if (opts.typeUserAttrs[type]) {
-      const customAttr = processTypeUserAttrs(opts.typeUserAttrs[type], values)
+    if (typeUserAttrs) {
+      const customAttr = processTypeUserAttrs(typeUserAttrs, values)
       advFields.push(customAttr)
     }
 
@@ -1224,6 +1226,8 @@ function FormBuilder(opts, element, $) {
 
     if (opts.typeUserEvents[type] && opts.typeUserEvents[type].onadd) {
       opts.typeUserEvents[type].onadd(field)
+    } else if (opts.typeUserEvents['*'] && opts.typeUserEvents['*'].onadd) {
+      opts.typeUserEvents['*'].onadd(field)
     }
 
     if (isNew) {
@@ -1610,6 +1614,8 @@ function FormBuilder(opts, element, $) {
 
     if (opts.typeUserEvents[type] && opts.typeUserEvents[type].onclone) {
       opts.typeUserEvents[type].onclone($clone[0])
+    } else if (opts.typeUserEvents['*'] && opts.typeUserEvents['*'].onclone) {
+      opts.typeUserEvents['*'].onclone($clone[0])
     }
 
     return $clone

--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -50,13 +50,13 @@ class FormRender {
       },
       templates: {}, // custom inline defined templates
       notify: {
-        error: error => {
+        error: /* istanbul ignore next */ error => {
           console.log(error)
         },
-        success: success => {
+        success: /* istanbul ignore next */ success => {
           console.log(success)
         },
-        warning: warning => {
+        warning: /* istanbul ignore next */ warning => {
           console.warn(warning)
         },
       },

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1057,7 +1057,7 @@ export default class Helpers {
       }
     })
 
-    const userEvents = config.opts.typeUserEvents[field.type]
+    const userEvents = Object.assign({}, config.opts.typeUserEvents['*'], config.opts.typeUserEvents[field.type])
 
     if (userEvents && userEvents.onremove) {
       userEvents.onremove(field)


### PR DESCRIPTION
Allow you to set a typeUserAttrs on all types and typeUserEvents on all types using the wildcard asterisk *. 

config applied too a specific type will override config applied to the wildcard (ie onadd for key text will override onadd for wildcard, attribute by name will override an attribute by the same name in wildcard config)

Tests and documentation updates included

@kevinchappell I choose using a wildcard setting rather than creating a userAttrs and userEvents config key, however please advise if you prefer creating new config options 

Fixes #https://github.com/kevinchappell/formBuilder/issues/611