### PR TITLE
Unify the regular and enhancedBootstrap UX

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -111,7 +111,6 @@ export const config = {}
 export const gridClassNames = {
   rowWrapperClass: 'rowWrapper',
   colWrapperClass: 'colWrapper',
-  tmpColWrapperClass: 'tempColWrapper',
   tmpRowPlaceholderClass: 'tempRowWrapper',
   invisibleRowPlaceholderClass: 'invisibleRowPlaceholder',
 }

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -32,6 +32,7 @@ const events = {
   fieldRendered: createNewEvent('fieldRendered'),
   fieldEditOpened: createNewEvent('fieldEditOpened'),
   fieldEditClosed: createNewEvent('fieldEditClosed'),
+  stageEmptied: createNewEvent('stageEmptied'),
 }
 
 export default events

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -2334,9 +2334,9 @@ function FormBuilder(opts, element, $) {
       const field = $(`#${fieldID}`)
       const fieldType = field.attr('type')
 
-      let label = field.html()
+      let label = $(`#label-${fieldID}`).html()
       if (fieldType === 'hidden' || fieldType === 'paragraph') {
-        label = field.val()
+        label = $(`#name-${fieldID}`).val()
       }
 
       if (!label) {

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -111,6 +111,13 @@ function FormBuilder(opts, element, $) {
     beforeStop: (evt, ui) => h.beforeStop.call(h, evt, ui),
     start: (evt, ui) => h.startMoving.call(h, evt, ui),
     stop: (evt, ui) => h.stopMoving.call(h, evt, ui),
+    change: function(event, ui) {
+      if (opts.prepend && ui.placeholder.index() < 1) {
+        $('li.form-prepend').after(ui.placeholder)
+      } else if (opts.append && ui.placeholder.index() >= ($stage.children('li').length - 1)) {
+        $('li.form-append').before(ui.placeholder)
+      }
+    },
     cancel: ['input', 'select', 'textarea', '.disabled-field', '.form-elements', '.btn', 'button', '.is-locked'].join(
       ', ',
     ),

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1146,7 +1146,7 @@ function FormBuilder(opts, element, $) {
     })
     const $li = $(field)
 
-    AttatchColWrapperHandler($li)
+    AttachColWrapperHandler($li)
 
     $li.data('fieldData', { attrs: values })
 
@@ -1251,7 +1251,7 @@ function FormBuilder(opts, element, $) {
     insertTargetIsColumn = false
   }
 
-  function AttatchColWrapperHandler(colWrapper) {
+  function AttachColWrapperHandler(colWrapper) {
     if (!enhancedBootstrapEnabled()) {
       return
     }
@@ -1361,7 +1361,7 @@ function FormBuilder(opts, element, $) {
           })
 
           $(ui.item).parent().replaceWith(rowWrapperNode)
-          AttatchColWrapperHandler($(ui.item))
+          AttachColWrapperHandler($(ui.item))
 
           colWrapper.appendTo(rowWrapperNode)
 

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1853,7 +1853,11 @@ function FormBuilder(opts, element, $) {
     evt.preventDefault()
     const currentItem = $(evt.target).parent().parent('li')
     const $clone = cloneItem(currentItem)
-    prepareCloneWrappers($clone, currentItem)
+    if (enhancedBootstrapEnabled()) {
+      prepareCloneWrappers($clone, currentItem)
+    } else {
+      $clone.insertAfter(currentItem)
+    }
     UpdatePreviewAndSave($clone)
 
     h.tmpCleanPrevHolder($clone.find('.prev-holder'))
@@ -1863,12 +1867,12 @@ function FormBuilder(opts, element, $) {
     }
   })
 
+  /**
+   * enhancedBootstrap feature helper post field clone
+   * @param $clone
+   * @param currentItem
+   */
   function prepareCloneWrappers($clone, currentItem) {
-    if (!enhancedBootstrapEnabled()) {
-      $clone.insertAfter(currentItem)
-      return
-    }
-
     const inputClassElement = $(`#className-${currentItem.attr('id')}`)
     const columnData = prepareFieldRow({})
 
@@ -2154,6 +2158,9 @@ function FormBuilder(opts, element, $) {
     return $stage.find('li').length > 0
   }
 
+  /**
+   * enhancedBootstrap feature helper
+   */
   function checkSetupBlankStage() {
     if (stageHasFields() || !enhancedBootstrapEnabled()) {
       return

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -267,7 +267,7 @@ function FormBuilder(opts, element, $) {
     }
 
     const $control = $(target).closest('li')
-    h.stopIndex = opts.append ? $stage.children('li').length - 1 : undefined
+    h.stopIndex = opts.append ? $stage.children().length - 1 : undefined
     processControl($control)
     h.save.call(h)
   })
@@ -1151,7 +1151,7 @@ function FormBuilder(opts, element, $) {
     $li.data('fieldData', { attrs: values })
 
     if (typeof h.stopIndex !== 'undefined') {
-      $('> li', d.stage).eq(h.stopIndex).before($li)
+      $(d.stage).children().eq(h.stopIndex).before($li)
     } else {
       $stage.append($li)
     }

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -197,6 +197,7 @@ function FormBuilder(opts, element, $) {
   $cbUL.on('mouseenter', function () {
     if (stageHasFields()) {
       $stage.children(tmpRowPlaceholderClassSelector).addClass(invisibleRowPlaceholderClass)
+    if (!h.stageIsEmpty()) {
     }
   })
 
@@ -261,7 +262,7 @@ function FormBuilder(opts, element, $) {
     }
 
     //Remove initial placeholder if simply clicking to add field into blank stage
-    if (!stageHasFields()) {
+    if (h.stageIsEmpty()) {
       $stage.find(tmpRowPlaceholderClassSelector).eq(0).remove()
     }
 
@@ -2154,15 +2155,11 @@ function FormBuilder(opts, element, $) {
       })
   }
 
-  function stageHasFields() {
-    return $stage.find('li').length > 0
-  }
-
   /**
    * enhancedBootstrap feature helper
    */
   function checkSetupBlankStage() {
-    if (stageHasFields() || !enhancedBootstrapEnabled()) {
+    if (!(enhancedBootstrapEnabled() && h.stageIsEmpty())) {
       return
     }
 

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -2037,21 +2037,38 @@ function FormBuilder(opts, element, $) {
       if (e.keyCode == 87 || e.keyCode == 38) {
         moveFieldUp(rowWrapper)
       }
+      switch (event.code) {
+        case 'KeyW':
+        case 'ArrowUp':
+          moveFieldUp(rowWrapper)
+          break
 
       if (e.keyCode == 83 || e.keyCode == 40) {
         moveFieldDown(rowWrapper)
       }
+        case 'KeyS':
+        case 'ArrowDown':
+          moveFieldDown(rowWrapper)
+          break
 
       if (e.keyCode == 65 || e.keyCode == 37) {
         moveFieldLeft()
       }
+        case 'KeyA':
+        case 'ArrowLeft':
+          moveFieldLeft()
+          break
 
       if (e.keyCode == 68 || e.keyCode == 39) {
         moveFieldRight()
-      }
+        case 'KeyD':
+        case 'ArrowRight':
+          moveFieldRight()
+          break
 
-      if (e.keyCode == 82) {
-        autoSizeRowColumns(rowWrapper, true)
+        case 'KeyR':
+          autoSizeRowColumns(rowWrapper, true)
+          break
       }
 
       buildGridModeCurrentRowInfo()

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1868,6 +1868,13 @@ function FormBuilder(opts, element, $) {
     }
   })
 
+  if (enhancedBootstrapEnabled()) {
+    $stage.on('stageEmptied', () => {
+      formRows = [] //Reset row count
+      checkSetupBlankStage()
+    })
+  }
+
   /**
    * enhancedBootstrap feature helper post field clone
    * @param $clone

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -87,7 +87,8 @@ export default class Helpers {
     const form = _this.d.stage
     const lastIndex = form.childNodes.length - 1
     const cancelArray = []
-    _this.stopIndex = ui.placeholder.index() - 1
+    //Find the index within the stage even if the placeholder is not a direct descendant
+    _this.stopIndex = ui.placeholder.closest('ul.stage-wrap > *').index() - 1
 
     if (!opts.sortableControls && ui.item.parent().hasClass('frmb-control')) {
       cancelArray.push(true)

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -746,6 +746,14 @@ export default class Helpers {
   }
 
   /**
+   * Check if stage is empty
+   * @return {boolean}
+   */
+  stageIsEmpty() {
+    return $(this.d.stage).find('li').length === 0
+  }
+
+  /**
    * If user re-orders the elements their order should be saved.
    * @param {Object} $cbUL our list of elements
    * @return {Array|false} fieldOrder

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1421,17 +1421,16 @@ export default class Helpers {
   /**
    * Return full row name (row-1)
    * @param className
-   * @returns {string|void}
+   * @returns {string}
    */
   getRowClass(className) {
-    if (!className) {
-      return
+    if (className) {
+      const splitClasses = className.split(' ').filter(x => x.startsWith('row-'))
+      if (splitClasses && splitClasses.length > 0) {
+        return splitClasses[0]
+      }
     }
-
-    const splitClasses = className.split(' ').filter(x => x.startsWith('row-'))
-    if (splitClasses && splitClasses.length > 0) {
-      return splitClasses[0]
-    }
+    return ''
   }
 
   /**
@@ -1440,13 +1439,11 @@ export default class Helpers {
    * @returns {number} Row number or 0 for invalid definitions
    */
   getRowValue(className) {
-    if (!className) {
-      return 0
-    }
-
-    const rowClass = this.getRowClass(className)
-    if (rowClass) {
-      return parseInt(rowClass.split('-')[1])
+    if (className) {
+      const rowClass = this.getRowClass(className)
+      if (rowClass) {
+        return parseInt(rowClass.split('-')[1])
+      }
     }
     return 0
   }
@@ -1466,43 +1463,43 @@ export default class Helpers {
    * @return {number} Column value between 1-12 or 0 for invalid definitions
    */
   getBootstrapColumnValue(className) {
-    if (!className) {
-      return 0
-    }
-
-    const bootstrapClass = this.getBootstrapColumnClass(className)
-    if (bootstrapClass) {
-      return parseInt(bootstrapClass.split('-')[2])
+    if (className) {
+      const bootstrapClass = this.getBootstrapColumnClass(className)
+      if (bootstrapClass) {
+        return parseInt(bootstrapClass.split('-')[2])
+      }
     }
     return 0
   }
 
   /**
-   * /Return the prefix (col-md)
+   * Return the prefix (col-md)
    * @param {string} className
-   * @returns {number|string}
+   * @returns {string}
    */
   getBootstrapColumnPrefix(className) {
-    if (!className) {
-      return 0
+    if (className) {
+      const bootstrapClass = this.getBootstrapColumnClass(className)
+      if (bootstrapClass) {
+        return `${bootstrapClass.split('-')[0]}-${bootstrapClass.split('-')[1]}`
+      }
     }
-
-    const bootstrapClass = this.getBootstrapColumnClass(className)
-    if (bootstrapClass) {
-      return `${bootstrapClass.split('-')[0]}-${bootstrapClass.split('-')[1]}`
-    }
+    return ''
   }
 
-  //Return full class name (col-md-6)
+  /**
+   * Return full class name (col-md-6)
+   * @param {string} className
+   * @returns {string}
+   */
   getBootstrapColumnClass(className) {
-    if (!className) {
-      return
+    if (className) {
+      const splitClasses = className.split(' ').filter(className => bootstrapColumnRegex.test(className))
+      if (splitClasses && splitClasses.length > 0) {
+        return splitClasses[0]
+      }
     }
-
-    const splitClasses = className.split(' ').filter(className => bootstrapColumnRegex.test(className))
-    if (splitClasses && splitClasses.length > 0) {
-      return splitClasses[0]
-    }
+    return ''
   }
 
   /**

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -743,6 +743,7 @@ export default class Helpers {
    */
   emptyStage(stage) {
     empty(stage).classList.remove('removing')
+    stage.dispatchEvent(events.stageEmptied)
     this.save()
   }
 

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -869,10 +869,10 @@ export default class Helpers {
 
       cleanResults.forEach(result => {
         if (result['columnInfo'].columnSize) {
-          const currentClassRow = rowContainer.attr('class')
+          const currentClassRow = _this.getBootstrapColumnClass(rowContainer.attr('class'))
           if (currentClassRow !== result['columnInfo'].columnSize) {
             //Keep the wrapping column div sync'd to the column property from the field
-            rowContainer.attr('class', `${result['columnInfo'].columnSize} ${this.formBuilder.colWrapperClass}`)
+            rowContainer.removeClass(currentClassRow).addClass(result['columnInfo'].columnSize)
             _this.tmpCleanPrevHolder(prevHolder)
           }
         }

--- a/src/sass/_stage.scss
+++ b/src/sass/_stage.scss
@@ -1,4 +1,6 @@
 .stage-wrap {
+  display: flex;
+  flex-direction: column;
   position: relative;
   padding: 0;
   margin: 0;
@@ -792,15 +794,24 @@
   white-space: nowrap;
 }
 
-.colHoverTempStyle {
-  padding-left: 7px !important;
-  padding-right: 7px !important;
+.colWithInsertButtons {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
   flex: 95 1 0% !important;
 }
 
 .rowWrapper {
   margin-left: 0 !important;
   margin-right: 0 !important;
+}
+
+.rowWrapper:last-child {
+  flex-grow: 1;
+}
+
+.rowWrapper:not(.tempRowWrapper) {
+  padding-top: 1em;
+  padding-bottom: 1em;
 }
 
 .btnAddControl {
@@ -820,6 +831,24 @@
 .hoverDropStyleInverse {
   background-color: #0d99f2;
   border: 1px dashed #e5f5f8;
+  min-height: 20px;
+}
+
+.hoverDropStyleInverse .colWrapper {
+  max-width: calc(100% - 40px);
+}
+
+.stage-wrap > .hoverDropStyleInverse {
+  width: 100%;
+}
+
+.rowWrapper > .hoverDropStyleInverse {
+  min-width: 40px;
+  flex-grow: 1;
+}
+
+.hoverDropStyleInverse:last-child {
+  flex-grow: 1;
 }
 
 .invisibleRowPlaceholder {

--- a/tests/bootstrap.test.js
+++ b/tests/bootstrap.test.js
@@ -1,0 +1,70 @@
+require('./setup-fb')
+require('./../src/js/form-builder.js')
+import layout from '../src/js/layout'
+import Helpers from '../src/js/helpers'
+
+describe('Test Boostrap Helper functions', () => {
+  let helper
+
+  beforeEach(async () => {
+    const fbWrap = $('<div>')
+    await fbWrap.formBuilder({}).promise
+    const formBuilder = fbWrap.data('formBuilder')
+    const layoutEngine = new layout({}, true, false)
+    helper = new Helpers(formBuilder.formID, layoutEngine, formBuilder )
+  })
+
+  test('tryParseColumnInfo', () => {
+    expect(helper.tryParseColumnInfo({className: 'col-md-5 row-1 random-class row col'})).toEqual({ 'columnSize': 'col-md-5', 'rowNumber': 1, })
+    expect(helper.tryParseColumnInfo({className: ''})).toEqual({ })
+  })
+
+  test('getDistanceBetweenPoints', () => {
+    expect(helper.getDistanceBetweenPoints(1,1,2,2)).toBe(1)
+    expect(helper.getDistanceBetweenPoints(-2,3,4,-7)).toBe(11)
+    expect(helper.getDistanceBetweenPoints(100,2,35,5)).toBe(65)
+  })
+
+  test('getRowClass', () => {
+    expect(helper.getRowClass('')).toBe('')
+    expect(helper.getRowClass('row row-4 col-md-2')).toBe('row-4')
+    expect(helper.getRowClass('row row-4 row-me col-md-2')).toBe('row-4')
+  })
+
+  test('getRowValue', () => {
+    expect(helper.getRowValue('row row-4 col-md-2')).toBe(4)
+    expect(helper.getRowValue('row row-5 row-me col-md-2')).toBe(5)
+  })
+
+  test('changeRowClass', () => {
+    expect(helper.changeRowClass('row row-4 col-md-2', 'row-6')).toBe('row row-row-6 col-md-2')
+  })
+
+  test('getBootstrapColumnValue', () => {
+    expect(helper.getBootstrapColumnValue('')).toBe(0)
+    expect(helper.getBootstrapColumnValue('no column class')).toBe(0)
+    expect(helper.getBootstrapColumnValue('col-md-5 row-1 random-class row col')).toBe(5)
+    expect(helper.getBootstrapColumnValue('col-md- row-1 random-class row col')).toBe(0)
+  })
+
+  test('getBootstrapColumnPrefix', () => {
+    expect(helper.getBootstrapColumnPrefix('')).toBe('')
+    expect(helper.getBootstrapColumnPrefix(undefined)).toBe('')
+    expect(helper.getBootstrapColumnPrefix('no column class')).toBe('')
+    expect(helper.getBootstrapColumnPrefix('col-md-5 row-1 random-class row col')).toBe('col-md')
+    expect(helper.getBootstrapColumnPrefix('col-md- row-1 random-class row col')).toBe('')
+  })
+
+  test('getBootstrapColumnClass', () => {
+    expect(helper.getBootstrapColumnClass('')).toBe('')
+    expect(helper.getBootstrapColumnClass(undefined)).toBe('')
+    expect(helper.getBootstrapColumnClass('no column class')).toBe('')
+    expect(helper.getBootstrapColumnClass('col-md-5 row-1 random-class row col')).toBe('col-md-5')
+    expect(helper.getBootstrapColumnClass('col-md- row-1 random-class row col')).toBe('')
+  })
+
+  test('changeBootstrapClass', () => {
+    expect(helper.changeBootstrapClass('col-md-5 row-1 random-class row col', 7)).toBe('col-md-7 row-1 random-class row col')
+  })
+
+})


### PR DESCRIPTION
This consolidates code between the regular and enhancedBootstrap formBuilder interfaces. It removes a lot of duplicate code and different styles.

Visually, regular formBuilder now has sortable placeholders that look the same as the ones in bootstrap, including when sorting fields on the stage. This improves UX as you can clearly see where elements will be dropped

In enhancedBootstrap, a lot of work was done into reducing the visible jumping that occurred when you dragged elements around, drop elements we also improved for existing rows with one column, previously you could have drop zones appear above and below the first column in a row, now they should appear on and left and right as expected.

Tests have been added for bootstrap functions in Helpers.js

The stage is changed to a display: flex container so that we can always have a visible drop zone taking up the remaining space on the stage. We use flex within the stage to support bootstrap so this should have minimal affect

summary
* Consolidate controls.sortable configuration into a single definition
 * Prevent control jumping by control + helper buttons invisible instead of removing them
 * Make stage a flex container and ensure the last drop zone is a flex-grow so that it spans remaining space in the stage
 * Use boostrap hover class in regular formBuilder to give additional user feedback on drop zones for sorting
 * Various equality checks from == to ===
 * stopIndex fixes for bootstrap function