### PR TITLE
Add subtype to the list of attributes that cannot be disabled

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -574,7 +574,7 @@ function FormBuilder(opts, element, $) {
       advFieldMap[numAttr] = type === 'number' ? () => numberAttribute(numAttr, values) :  () => textAttribute(numAttr, values)
     })
 
-    const noDisable = ['name', 'className']
+    const noDisable = ['name', 'className', 'subtype', ]
 
     const typeUserAttrs = Object.assign({}, opts.typeUserAttrs['*'], opts.typeUserAttrs[type])
 


### PR DESCRIPTION
Since a control may require subtype we hide it rather than remove it when disabled via disableAttrs. Fields added via the API may still set this value and the subtype will be returned by getData...

Fixes: #1212