### PR TITLE
Allow string row identifiers in bootstrap rows

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1334,7 +1334,7 @@ export default class Helpers {
 
   /**
    * @typedef BsColumnInfo
-   * @param {number} [rowNumber]
+   * @param {string} [rowUniqueId]
    * @param {string} [columnSize]
    */
 
@@ -1351,7 +1351,7 @@ export default class Helpers {
       if (classes && classes.length > 0) {
         classes.forEach(element => {
           if (element.startsWith('row-')) {
-            result['rowNumber'] = parseInt(element.replace('row-', '').trim())
+            result['rowUniqueId'] = element.replace('row-', '').trim()
           } else {
             result['columnSize'] = element
           }
@@ -1434,18 +1434,18 @@ export default class Helpers {
   }
 
   /**
-   * Return the row value i.e row-2 would return 2
+   * Return the row value i.e row-2 would return '2'
    * @param {string} className
-   * @returns {number} Row number or 0 for invalid definitions
+   * @returns {string} Row value as string or '0' for invalid definitions
    */
   getRowValue(className) {
     if (className) {
       const rowClass = this.getRowClass(className)
       if (rowClass) {
-        return parseInt(rowClass.split('-')[1])
+        return rowClass.split('-')[1]
       }
     }
-    return 0
+    return '0'
   }
 
   /**

--- a/tests/bootstrap.test.js
+++ b/tests/bootstrap.test.js
@@ -15,7 +15,8 @@ describe('Test Boostrap Helper functions', () => {
   })
 
   test('tryParseColumnInfo', () => {
-    expect(helper.tryParseColumnInfo({className: 'col-md-5 row-1 random-class row col'})).toEqual({ 'columnSize': 'col-md-5', 'rowNumber': 1, })
+    expect(helper.tryParseColumnInfo({className: 'col-md-5 row-1 random-class row col'})).toEqual({ 'columnSize': 'col-md-5', 'rowUniqueId': '1', })
+    expect(helper.tryParseColumnInfo({className: 'col-md-5 row-unique random-class row col'})).toEqual({ 'columnSize': 'col-md-5', 'rowUniqueId': 'unique', })
     expect(helper.tryParseColumnInfo({className: ''})).toEqual({ })
   })
 
@@ -25,6 +26,7 @@ describe('Test Boostrap Helper functions', () => {
     expect(helper.getDistanceBetweenPoints(100,2,35,5)).toBe(65)
   })
 
+  //Returns first matching row-* value
   test('getRowClass', () => {
     expect(helper.getRowClass('')).toBe('')
     expect(helper.getRowClass('row row-4 col-md-2')).toBe('row-4')
@@ -32,8 +34,9 @@ describe('Test Boostrap Helper functions', () => {
   })
 
   test('getRowValue', () => {
-    expect(helper.getRowValue('row row-4 col-md-2')).toBe(4)
-    expect(helper.getRowValue('row row-5 row-me col-md-2')).toBe(5)
+    expect(helper.getRowValue('row row-4 col-md-2')).toBe('4')
+    expect(helper.getRowValue('row row-5 row-me col-md-2')).toBe('5')
+    expect(helper.getRowValue('row row-myrow row-me col-md-2')).toBe('myrow')
   })
 
   test('changeRowClass', () => {


### PR DESCRIPTION
Allow Bootstrap row identifiers to be any string value after row)- (eg row-myrow). This allows default fields or inputSets to be pre-configured with named rows which can then be targeted with CSS rules.