### PR TITLE
Define icon() on templateControl

### DIFF
--- a/src/js/customControls.js
+++ b/src/js/customControls.js
@@ -53,6 +53,7 @@ export default class customControls {
       }
       templateControl.definition = {}
       templateControl.label = type => _this.label(type)
+      templateControl.icon = type => _this.icon(type)
       this.templateControlRegister[templateName] = templateControl
     })
 

--- a/tests/control/custom.test.js
+++ b/tests/control/custom.test.js
@@ -224,4 +224,33 @@ describe('Test Custom Control', () => {
     expect(renderedCtl.eq(1).attr('type')).toBe('text')
     expect(renderedCtl.eq(1).attr('id')).toMatch(new RegExp('^text-.*'))
   })
+
+  test('custom control with no icon', async () => {
+    const fbWrap = $('<div>')
+    const fields = [
+      {
+        className: 'form-control custom-class',
+        label: 'Custom Text Field',
+        type: 'customText',
+        //icon: '🔢'
+      },
+    ]
+    const templates = {
+      customText: function(fieldData) {
+        return {
+          field: this.markup('input', null, fieldData)
+        }
+      },
+    }
+
+    const fb = await $(fbWrap).formBuilder({fields, templates, }).promise
+    const field = {
+      type: 'customText',
+      className: 'form-control api-class',
+      value: 'Added by API',
+    }
+    fb.actions.addField(field)
+
+    expect(fbWrap.find('.stage-wrap li')).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
Add missing icon() fallback when a icon is not defined on a custom control

Fixes: #1464