### PR TITLE
Fix bugs related to textarea.quill

### DIFF
--- a/src/js/control/textarea.quill.js
+++ b/src/js/control/textarea.quill.js
@@ -49,6 +49,9 @@ export default class controlQuill extends controlTextarea {
     //Textareas do not have an attribute 'type'
     delete attrs['type']
     this.field = this.markup('div', null, attrs)
+    if (this.field.classList.contains('form-control')) {
+      this.field.classList.remove('form-control')
+    }
     return this.field
   }
 

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1667,7 +1667,7 @@ function FormBuilder(opts, element, $) {
   })
 
   $stage.on('dblclick', 'li.form-field', e => {
-    if (['select', 'input', 'label'].includes(e.target.tagName.toLowerCase()) || e.target.contentEditable === 'true') {
+    if (['select', 'input', 'label','textarea',].includes(e.target.tagName.toLowerCase()) || e.target.isContentEditable === true) {
       return
     }
     e.stopPropagation()

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -663,7 +663,7 @@ export const bootstrapColumnRegex = /^col-(xs|sm|md|lg)-([^\s]+)/
  * @returns {string[]}
  */
 export const getAllGridRelatedClasses = className => {
-  return className.split(' ').filter(x => bootstrapColumnRegex.test(x) || x.startsWith('row-'))
+  return (typeof className === 'string') ? className.split(' ').filter(x => bootstrapColumnRegex.test(x) || x.startsWith('row-')) : []
 }
 
 /**


### PR DESCRIPTION
1. quill.textarea contains SVG graphics. This caused getAllGridRelatedClasses to throw a exception due to SVG className property being a SVGAnimatedString instead of a string
2. quill.textarea is incompatible with form-control class, strip this in the build stage Fixes #677
3. Double clicking on a textarea or on content within a content editable field (eg textarea.quill) would cause the edit box to toggle. Add textarea to the exclusion list and also use the isContentEditable property instead of the contentEditable attribute to detect the editable state