### PR TITLE
Set the preview property for custom controls

### DIFF
--- a/src/js/control/custom.js
+++ b/src/js/control/custom.js
@@ -33,7 +33,7 @@ export default class controlCustom extends control {
       'description',
       'subtype',
       'id',
-      'isPreview',
+      'preview',
       'required',
       'title',
       'aria-required',

--- a/tests/control/custom.test.js
+++ b/tests/control/custom.test.js
@@ -23,7 +23,7 @@ describe('Test Custom Control', () => {
       }
     }
 
-    const fb = await $(fbWrap).formBuilder({fields, templates}).promise
+    const fb = await fbWrap.formBuilder({fields, templates}).promise
     const field = {
       type: 'starRating',
       className: 'form-control'
@@ -32,7 +32,7 @@ describe('Test Custom Control', () => {
 
     expect(cbOnRender.mock.calls).toHaveLength(1)
 
-    $(fbWrap).find('li.input-control[data-type="starRating"]').click()
+    fbWrap.find('li.input-control[data-type="starRating"]').click()
 
     expect(cbOnRender.mock.calls).toHaveLength(2)
   })
@@ -58,11 +58,11 @@ describe('Test Custom Control', () => {
       }
     }
 
-    const fr = await $(fbWrap).formRender({formData, templates}).promise
+    fbWrap.formRender({formData, templates})
 
     expect(cbOnRender.mock.calls).toHaveLength(1)
 
-    expect($(fbWrap).find('#starRating-1697591966052-0')[0].outerHTML).toBe('<span id="starRating-1697591966052-0"></span>')
+    expect(fbWrap.find('#starRating-1697591966052-0')[0].outerHTML).toBe('<span id="starRating-1697591966052-0"></span>')
 
   })
 
@@ -92,7 +92,7 @@ describe('Test Custom Control', () => {
       }
     }
 
-    const fb = await $(fbWrap).formBuilder({fields, templates}).promise
+    const fb = await fbWrap.formBuilder({fields, templates}).promise
     const field = {
       type: 'text',
       className: 'form-control'
@@ -101,7 +101,7 @@ describe('Test Custom Control', () => {
 
     expect(cbOnRender.mock.calls).toHaveLength(1)
 
-    $(fbWrap).find('li.input-control[data-type="text"]').click()
+    fbWrap.find('li.input-control[data-type="text"]').click()
 
     expect(cbOnRender.mock.calls).toHaveLength(2)
   })
@@ -135,7 +135,7 @@ describe('Test Custom Control', () => {
       },
     }
 
-    const fb = await $(fbWrap).formBuilder({fields, templates, typeUserAttrs: { customText: { dataAttr: { value: '', label: 'textDataAttr'} } }}).promise
+    const fb = await fbWrap.formBuilder({fields, templates, typeUserAttrs: { customText: { dataAttr: { value: '', label: 'textDataAttr'} } }}).promise
     const field = {
       type: 'customText',
       className: 'form-control api-class',
@@ -143,16 +143,16 @@ describe('Test Custom Control', () => {
     }
     fb.actions.addField(field)
 
-    let renderedCtl = $(fbWrap).find('.prev-holder input')
+    let renderedCtl = fbWrap.find('.prev-holder input')
     expect(renderedCtl.attr('class')).toBe('form-control api-class')
     expect(renderedCtl.attr('value')).toBe('Added by API')
     expect(renderedCtl.attr('id')).toMatch(new RegExp('^customText-.*'))
 
     fb.actions.clearFields()
 
-    $(fbWrap).find('li.input-control[data-type="customText"]').click()
+    fbWrap.find('li.input-control[data-type="customText"]').click()
 
-    renderedCtl = $(fbWrap).find('.prev-holder input')
+    renderedCtl = fbWrap.find('.prev-holder input')
     expect(renderedCtl.attr('class')).toBe('form-control custom-class')
     expect(renderedCtl.attr('value')).toBe('String to look for')
     expect(renderedCtl.attr('id')).toMatch(new RegExp('^customText-.*'))
@@ -209,11 +209,11 @@ describe('Test Custom Control', () => {
 
     ]
 
-    const fb = await $(fbWrap).formBuilder({fields, templates, inputSets}).promise
+    const fb = await fbWrap.formBuilder({fields, templates, inputSets}).promise
 
-    $(fbWrap).find('li.input-set-control[data-type="test-input-set"]').click()
+    fbWrap.find('li.input-set-control[data-type="test-input-set"]').click()
 
-    const renderedCtl = $(fbWrap).find('.prev-holder input')
+    const renderedCtl = fbWrap.find('.prev-holder input')
     expect(renderedCtl.eq(0).attr('class')).toBe('form-control custom-class')
     expect(renderedCtl.eq(0).attr('value')).toBe('String to look for')
     expect(renderedCtl.eq(0).attr('type')).toBe('customText')
@@ -243,7 +243,7 @@ describe('Test Custom Control', () => {
       },
     }
 
-    const fb = await $(fbWrap).formBuilder({fields, templates, }).promise
+    const fb = await fbWrap.formBuilder({fields, templates, }).promise
     const field = {
       type: 'customText',
       className: 'form-control api-class',
@@ -272,7 +272,7 @@ describe('Test Custom Control', () => {
       }
     }
 
-    const fb = await $(fbWrap).formBuilder({fields, templates}).promise
+    const fb = await fbWrap.formBuilder({fields, templates}).promise
     const field = {
       type: 'customString',
       className: 'form-control row-1 col-md-12'
@@ -280,7 +280,7 @@ describe('Test Custom Control', () => {
     fb.actions.addField(field)
 
     expect(fbWrap.find('.stage-wrap li[type="customString"]')).toHaveLength(1)
-    const renderedCtl = $(fbWrap).find('.prev-holder span')
+    const renderedCtl = fbWrap.find('.prev-holder span')
     expect(renderedCtl.attr('class')).toBe('form-control')
     expect(renderedCtl.text()).toBe('Placeholder')
   })
@@ -303,7 +303,7 @@ describe('Test Custom Control', () => {
       }
     }
 
-    const fb = await $(fbWrap).formBuilder({fields, templates}).promise
+    const fb = await fbWrap.formBuilder({fields, templates}).promise
     const field = {
       type: 'customString',
       className: 'form-control row-1 col-md-12'
@@ -311,11 +311,59 @@ describe('Test Custom Control', () => {
     fb.actions.addField(field)
 
     expect(fbWrap.find('.stage-wrap li[type="customString"]')).toHaveLength(1)
-    expect($(fbWrap).find('.prev-holder div')).toHaveLength(2)
-    expect($(fbWrap).find('.prev-holder input')).toHaveLength(1)
-    expect($(fbWrap).find('.prev-holder span')).toHaveLength(1)
-    const renderedCtl = $(fbWrap).find('.prev-holder span')
+    expect(fbWrap.find('.prev-holder div')).toHaveLength(2)
+    expect(fbWrap.find('.prev-holder input')).toHaveLength(1)
+    expect(fbWrap.find('.prev-holder span')).toHaveLength(1)
+    const renderedCtl = fbWrap.find('.prev-holder span')
     expect(renderedCtl.attr('class')).toBe('form-control')
     expect(renderedCtl.text()).toBe('Placeholder')
+  })
+
+  test('preview property set to true for custom control in formBuilder', async () => {
+    const fbWrap = $('<div>')
+
+    const fields = [{
+      label: 'Custom with string field',
+      attrs: {
+        type: 'customString'
+      },
+      icon: '🌟'
+    }]
+    const templates = {
+      customString: function(fieldData) {
+        return {
+          field: (fieldData.preview) ? '<span>preview</span>' : '<span>not preview</span>'
+        }
+      }
+    }
+
+    const fb = await fbWrap.formBuilder({fields, templates}).promise
+    const field = { type: 'customString', }
+    fb.actions.addField(field)
+
+    const renderedCtl = fbWrap.find('.prev-holder span')
+    expect(renderedCtl.text()).toBe('preview')
+  })
+
+  test('preview property falsy for custom control in formRender', async () => {
+    const fbWrap = $('<div>')
+    const formData = [
+      {
+        'type': 'customString',
+        'required': false,
+        'label': 'custom',
+        'name': 'custom-string'
+      },
+    ]
+    const templates = {
+      customString: function(fieldData) {
+        return {
+          field: (fieldData.preview) ? '<span>preview</span>' : '<span>not preview</span>'
+        }
+      }
+    }
+
+    fbWrap.formRender({formData, templates})
+    expect(fbWrap.find('span')[0].textContent).toBe('not preview')
   })
 })


### PR DESCRIPTION
Custom control was attempting to use the property isPreview, this does not exist as it is deleted in control.js constructor. Set the preview property in the same way we send along preview to built-in controls

Fixes: #995