### PR TITLE
Fix GH-1477 userData incorrect when unchecking defaulted selected checkboxes

### DIFF
--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -303,7 +303,7 @@ class FormRender {
         // Skip disabled fields -- This will not have user data available
         if (definedField.disabled) continue
 
-        definedField.userData = userDataMap[definedField.name]
+        definedField.userData = userDataMap[definedField.name] ?? []
       }
     })
 

--- a/tests/form-render.test.js
+++ b/tests/form-render.test.js
@@ -113,4 +113,30 @@ describe('Form Rendering', () => {
     textarea = container.find('#textarea-elem')
     expect(textarea).not.toHaveLength(0)
   })
+
+  test('check userData when no value set', () => {
+    const container = $('<div>')
+    const formData = [
+      {type: 'textarea', name: 'input-textarea'},
+      {type: 'text', name: 'input-text'},
+      {type: 'checkbox-group', name: 'input-checkbox-group', 'values': [ { 'label': 'O', 'value': 'option-1', 'selected': false }, ]},
+      {type: 'radio-group', name: 'input-radio-group', 'values': [ { 'label': 'O', 'value': 'option-1', 'selected': false }, ]},
+      {type: 'select', name: 'input-select', placeholder: 'Select...', 'values': [ { 'label': 'O', 'value': 'option-1', 'selected': false }, ]},
+      {type: 'select', name: 'input-select-multiple', placeholder: 'Select...', multiple: true, 'values': [ { 'label': 'O', 'value': 'option-1', 'selected': false }, ]},
+    ]
+    container.formRender({ formData })
+
+    const userData = {}
+
+    container.formRender('userData').forEach(elem => {
+        userData[elem.name] = elem.userData
+    })
+
+    expect(userData['input-textarea']).toStrictEqual([''])
+    expect(userData['input-text']).toStrictEqual([''])
+    expect(userData['input-checkbox-group']).toStrictEqual([])
+    expect(userData['input-radio-group']).toStrictEqual([])
+    expect(userData['input-select']).toStrictEqual([])
+    expect(userData['input-select-multiple']).toStrictEqual([])
+  })
 })


### PR DESCRIPTION
@kevinchappell I believe setting this default empty array is the best method to ensure than when no value is available it is set. This ensures that any default values are not selected on subsequent loads.

Fixes: #1477