### PR TITLE
Set default floor for numerical row index

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1479,7 +1479,7 @@ function FormBuilder(opts, element, $) {
           nextRow = 1
         } else {
           const numericalRows = formRows.filter(value => !isNaN(value) && !isNaN(parseInt(value))).map(str => parseInt(str))
-          nextRow = (Math.max(...numericalRows) + 1)
+          nextRow = (Math.max(...numericalRows, 0) + 1)
         }
 
         result.rowUniqueId = nextRow.toString()


### PR DESCRIPTION
Missed applying this patch in PR#1463.

 Ensure a default value is set for when rows exists but none have numerical indices