### PR TITLE
Fix for https://github.com/kevinchappell/formBuilder/issues/699

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -936,7 +936,6 @@ function FormBuilder(opts, element, $) {
 
     let attrVal = values[attribute] || ''
     let attrLabel = mi18n.get(attribute) || attribute
-    const typeVal = values['type'] || ''
 
     if (attribute === 'label') {
       if (textArea.includes(values.type)) {

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -964,10 +964,8 @@ function FormBuilder(opts, element, $) {
       if (attribute === 'label' && !opts.disableHTMLLabels) {
         inputConfig.contenteditable = true
         attributefield += m('div', attrVal, inputConfig).outerHTML
-      } else if (typeVal.includes('textarea') && attribute === 'value') {
-        inputConfig.contenteditable = true
-        inputConfig.value = attrVal
-        attributefield += `<textarea ${attrString(inputConfig)}>${inputConfig.value}</textarea>`
+      } else if (values.type === 'textarea' && attribute === 'value') {
+        attributefield += m('textarea', attrVal, inputConfig).outerHTML
       } else {
         inputConfig.value = attrVal
         inputConfig.type = 'text'

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -936,6 +936,7 @@ function FormBuilder(opts, element, $) {
 
     let attrVal = values[attribute] || ''
     let attrLabel = mi18n.get(attribute) || attribute
+    const typeVal = values['type'] || ''
 
     if (attribute === 'label') {
       if (textArea.includes(values.type)) {
@@ -963,6 +964,10 @@ function FormBuilder(opts, element, $) {
       if (attribute === 'label' && !opts.disableHTMLLabels) {
         inputConfig.contenteditable = true
         attributefield += m('div', attrVal, inputConfig).outerHTML
+      } else if (typeVal.includes('textarea') && attribute === 'value') {
+        inputConfig.contenteditable = true
+        inputConfig.value = attrVal
+        attributefield += `<textarea ${attrString(inputConfig)}>${inputConfig.value}</textarea>`
       } else {
         inputConfig.value = attrVal
         inputConfig.type = 'text'
@@ -1713,6 +1718,11 @@ function FormBuilder(opts, element, $) {
           selectedOption.checked = prevOptions[i].checked
         })
       }
+    } else if (field.type === 'textarea') {
+      const fieldVal = document.getElementById('value-' + field.id)
+      if (fieldVal) {
+        fieldVal.innerHTML = e.target.value
+      } 
     } else {
       const fieldVal = document.getElementById('value-' + field.id)
       if (fieldVal) {

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1716,11 +1716,6 @@ function FormBuilder(opts, element, $) {
           selectedOption.checked = prevOptions[i].checked
         })
       }
-    } else if (field.type === 'textarea') {
-      const fieldVal = document.getElementById('value-' + field.id)
-      if (fieldVal) {
-        fieldVal.innerHTML = e.target.value
-      } 
     } else {
       const fieldVal = document.getElementById('value-' + field.id)
       if (fieldVal) {


### PR DESCRIPTION
After recently using this great project, I found that TextArea content are not being preserved, as they are being converted into a single value input of input[type=text].  This removes formatting from the TextArea such as line feeds etc.

I have amended the code so that TextArea are provided a proper TextArea control, and that the innerHTML data is preserved.

I believe this solved the following [issue](https://github.com/kevinchappell/formBuilder/issues/699).

Fixes: #699
