### PR TITLE
Multiple Bootstrap improvements

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1268,7 +1268,7 @@ function FormBuilder(opts, element, $) {
 
     wrapperClone.insertAfter($(rowWrapperNode))
     setupSortableRowWrapper(wrapperClone)
-    $stage.find(rowWrapperClassSelector + ':last-child').removeClass(invisibleRowPlaceholderClass)
+    $stage.find(rowWrapperClassSelector + ':last-of-type').removeClass(invisibleRowPlaceholderClass)
   }
 
   function ResetAllInvisibleRowPlaceholders() {
@@ -1278,7 +1278,7 @@ function FormBuilder(opts, element, $) {
       SetupInvisibleRowPlaceholders($(elem))
     })
 
-    $stage.find(rowWrapperClassSelector + ':last-child').removeClass(invisibleRowPlaceholderClass)
+    $stage.find(rowWrapperClassSelector + ':last-of-type').removeClass(invisibleRowPlaceholderClass)
   }
 
   function setupSortableRowWrapper(rowWrapperNode) {

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -135,6 +135,7 @@ function FormBuilder(opts, element, $) {
     cursor: 'move',
     scroll: false,
     placeholder: 'hoverDropStyleInverse ui-state-highlight',
+    tolerance: 'pointer',
     start: (evt, ui) => h.startMoving.call(h, evt, ui),
     stop: (evt, ui) => {
       h.stopMoving.call(h, evt, ui)

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1182,6 +1182,7 @@ function FormBuilder(opts, element, $) {
 
       if (newRowCreated) {
         setupSortableRowWrapper(rowWrapperNode)
+        hideInvisibleRowPlaceholders()
         SetupInvisibleRowPlaceholders(rowWrapperNode)
         if (opts.enableColumnInsertMenu) {
           $(rowWrapperNode).off('mouseenter')


### PR DESCRIPTION
- Only setup sortable row wrapper and invisible row placeholders when adding a row to the stage. 
- Calling SetupInvisibleRowPlaceholders with an existing row led to duplicated invisible row placeholders.
- Calling setupSortableRowWrapper on an existing row causes unnecessary reinitialisation of jQuery.ui sortable
- When initialising from formBuilder don't move the row to the LI insertion point since we will be moving the LI into the row in the next line.
- Fix some jumping around of row placeholders due to control panel sortable configuration using intersect rather than pointer 