### PR TITLE
Allow hierarchically defined controlConfig for type and subtype

### DIFF
--- a/src/js/control.js
+++ b/src/js/control.js
@@ -50,7 +50,7 @@ export default class control {
       control.controlConfig = {}
     }
     const classId = this.subtype ? this.type + '.' + this.subtype : this.type
-    this.classConfig = jQuery.extend({}, control.controlConfig[classId] || {})
+    this.classConfig = jQuery.extend({}, control.controlConfig[this.type] || {}, control.controlConfig[classId] || {})
 
     // if subtype, update the config type for injecting into DOM elements
     if (this.subtype) {


### PR DESCRIPTION
Currently if a custom control has multiple subtypes, you cannot define controlConfig for all subtypes at once, multiple definitions are required (See https://github.com/lucasnetau/formBuilder-plugin-media)

This feature allows controlConfig for the type and subtype to be combined with subtype able to override type definition