### PR TITLE
Fix table rendering on render.md

### DIFF
--- a/docs/formRender/actions/render.md
+++ b/docs/formRender/actions/render.md
@@ -3,8 +3,9 @@
 Programmatically render or re-render a formRender instance with new data
 
 Arguments
+
 | Arg  | Type | Value(s) | Default |
-| ------------- | ------------- |------------- |------------- |
+|-------------|-------------|-------------|-------------|
 | formData | {Array|String} | `[{}]`, `'<>'`, `'[{}]'` | null |
 | options | {Object} | override options for new render | {} |
 


### PR DESCRIPTION
Table was not rendering due to the missing newline between the title and the table definition.