### PR TITLE
Fix loading of userData into tinymce control after initialisation

### DIFF
--- a/src/js/control/textarea.tinymce.js
+++ b/src/js/control/textarea.tinymce.js
@@ -101,14 +101,14 @@ export default class controlTinymce extends controlTextarea {
     const afterInit = function (inst) {
       // Set userData
       if (copiedData) {
-        inst.setContent(copiedData)
+        inst[0].setContent(copiedData)
       } else if (userData) {
-        inst.setContent(userData)
+        inst[0].setContent(userData)
       }
     }
 
     setTimeout(() => {
-      // initialise the editor
+      // initialise the editor within a timeout so that the main thread can continue while tinymce initialises
       window.tinymce.init(options).then(afterInit)
     }, 0)
   }


### PR DESCRIPTION
editorInstances are an array in the tinymce initialisation resolved promise. Fix loading of the data into the first and only initialised editor.

Improve the tinymce testcase by implementing a function to wait for the tinymce control to be completely initialised and then verify that userData has been restored

Fixes #1535 