### PR TITLE
Fix restoring value of typeUserAttr select when attribute name is className

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -784,14 +784,14 @@ function FormBuilder(opts, element, $) {
    */
   function selectUserAttrs(name, fieldData) {
     const { multiple, options, label: labelText, value, class: classname, className, ...restData } = fieldData
+    const selectValues = fieldData.hasOwnProperty(name) ? fieldData[name] : value || []
     const optis = Object.keys(options).map(val => {
       const attrs = { value: val }
       const optionTextVal = options[val]
       const optionText = Array.isArray(optionTextVal) ? mi18n.get(...optionTextVal) || optionTextVal[0] : optionTextVal
-      if (Array.isArray(value) ? value.includes(val) : val === value) {
-        attrs.selected = null
+      if (Array.isArray(selectValues) ? selectValues.includes(val) : val === selectValues) {
+        attrs.selected = true
       }
-
       return m('option', optionText, attrs)
     })
 

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -701,7 +701,7 @@ function FormBuilder(opts, element, $) {
         const attrValType = userAttrType(typeUserAttr[attribute])
         if (attrValType !== 'undefined') {
           const orig = mi18n.get(attribute)
-          const tUA = typeUserAttr[attribute]
+          const tUA = Object.assign({}, typeUserAttr[attribute]) //Ensure we work on a copy of the attributes
           let origValue = tUA.value
           if (attrValType === 'boolean') {
             tUA[attribute] ??= tUA.value
@@ -722,7 +722,6 @@ function FormBuilder(opts, element, $) {
           }
 
           i18n[attribute] = orig
-          tUA.value = origValue
         } else if (attrValType === 'undefined' && hasSubType(values, attribute)) {
           advField.push(processTypeUserAttrs(typeUserAttr[attribute], values))
         } else {

--- a/tests/form-builder.test.js
+++ b/tests/form-builder.test.js
@@ -524,7 +524,7 @@ describe('FormBuilder typeUserAttrs detection', () => {
               'blue form-control': 'Blue'
             },
             style: 'border: 1px solid red',
-            value: 'Red',
+            value: 'red form-control',
           }
         },
       },
@@ -541,6 +541,43 @@ describe('FormBuilder typeUserAttrs detection', () => {
     const input = fbWrap.find('.text-field .className-wrap select')
     expect(input.length).toBe(1)
     expect(input.val()).toEqual('green form-control')
+  })
+
+  test('fix GH-1534', async() => {
+    const config = {
+      typeUserAttrs: {
+        '*': {
+          className: {
+            label: 'Class',
+            multiple: false,
+            options: {
+              'red form-control': 'Red',
+              'green form-control': 'Green',
+              'blue form-control': 'Blue'
+            },
+            style: 'border: 1px solid red',
+            value: 'red form-control',
+          }
+        },
+      },
+    }
+    const fbWrap = $('<div>')
+    const fb = await fbWrap.formBuilder(config).promise
+    fb.actions.setData([
+      {
+        type: 'text',
+        className: 'green form-control',
+      },
+      {
+        type: 'text',
+        className: 'blue form-control',
+      }
+    ])
+
+    const input = fbWrap.find('.text-field .className-wrap select')
+    expect(input.length).toBe(2)
+    expect($(input.get(0)).val()).toEqual('green form-control')
+    expect($(input.get(1)).val()).toEqual('blue form-control')
   })
 
   test('can load formData with value for multi select typeUserAttr into stage', async() => {

--- a/tests/form-builder.test.js
+++ b/tests/form-builder.test.js
@@ -485,8 +485,39 @@ describe('FormBuilder typeUserAttrs detection', () => {
       typeUserAttrs: {
         '*': {
           testSelectAttribute: {
-            label: 'Class', // i18n support by passing and array eg. ['optionCount', {count: 3}]
-            multiple: true, // optional, omitting generates normal <select>
+            label: 'Test Select',
+            multiple: false,
+            options: {
+              'red form-control': 'Red',
+              'green form-control': 'Green',
+              'blue form-control': 'Blue'
+            },
+            style: 'border: 1px solid red',
+            value: 'red form-control',
+          }
+        },
+      },
+    }
+    const fbWrap = $('<div>')
+    const fb = await fbWrap.formBuilder(config).promise
+    fb.actions.setData([
+      {
+        type: 'text',
+        testSelectAttribute: 'green form-control',
+      }
+    ])
+
+    const input = fbWrap.find('.text-field .testSelectAttribute-wrap select')
+    expect(input.length).toBe(1)
+    expect(input.val()).toEqual('green form-control')
+  })
+  test('can load formData with value for select typeUserAttr into stage where attribute name is className', async() => {
+    const config = {
+      typeUserAttrs: {
+        '*': {
+          className: {
+            label: 'Class',
+            multiple: false,
             options: {
               'red form-control': 'Red',
               'green form-control': 'Green',
@@ -503,13 +534,44 @@ describe('FormBuilder typeUserAttrs detection', () => {
     fb.actions.setData([
       {
         type: 'text',
-        testSelectAttribute: 'green form-control',
+        className: 'green form-control',
       }
     ])
 
+    const input = fbWrap.find('.text-field .className-wrap select')
+    expect(input.length).toBe(1)
+    expect(input.val()).toEqual('green form-control')
+  })
+
+  test('can load formData with value for multi select typeUserAttr into stage', async() => {
+    const config = {
+      typeUserAttrs: {
+        '*': {
+          testSelectAttribute: {
+            label: 'Test Select',
+            multiple: true,
+            options: {
+              'red form-control': 'Red',
+              'green form-control': 'Green',
+              'blue form-control': 'Blue'
+            },
+            style: 'border: 1px solid red',
+            value: 'red form-control',
+          }
+        },
+      },
+    }
+    const fbWrap = $('<div>')
+    const fb = await fbWrap.formBuilder(config).promise
+    fb.actions.setData([
+      {
+        type: 'text',
+        testSelectAttribute: ['green form-control','blue form-control'],
+      }
+    ])
     const input = fbWrap.find('.text-field .testSelectAttribute-wrap select')
     expect(input.length).toBe(1)
-    expect(input.val()).toEqual(['green form-control'])
+    expect(input.val()).toEqual(['green form-control','blue form-control'])
   })
 })
 
@@ -530,7 +592,7 @@ describe('FormBuilder can return formData', () => {
         'name': 'textarea-1696482495077',
         'required': false,
       }
-      ]
+  ]
 
   test('as JSON', async () => {
     const fbWrap = $('<div>')


### PR DESCRIPTION
Built in attribute className was not correctly restored when overridden with a typeUserAttr definition of type select. Additionally the typeUserAttr array was mutated by the allocation to tUA and therefore leaked between controls, an copy is now made of the object before any mutation

Note: this configuration does not work when enableEnhancedBootstrapGrid = true due to the feature using className to keep track of row and column information.

Added test cases to cover

Fixes: #1534 