### PR TITLE
fix: ensure rows attribute is forced to a positive integer

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -1824,7 +1824,7 @@ function FormBuilder(opts, element, $) {
     }
   })
 
-  $stage.on('blur', 'input.fld-maxlength', e => {
+  $stage.on('blur', 'input.fld-maxlength, input.fld-rows', e => {
     e.target.value = forceNumber(e.target.value)
   })
 

--- a/src/sass/_stage.scss
+++ b/src/sass/_stage.scss
@@ -656,7 +656,7 @@
         border: 1px solid $error;
       }
 
-      &.fld-maxlength {
+      &.fld-maxlength, &.fld-rows {
         width: 75px;
       }
 


### PR DESCRIPTION
Rows is a positive integer attribute for text-area and should be treated in the same way as max-length

Closes #1555