### PR TITLE
Fix GH-1536 kc-toggle doesn't work with duplicated ids

### DIFF
--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -93,6 +93,7 @@ export default class controlSelect extends control {
           const labelAttrs = { for: optionAttrs.id }
           let output = [input, this.markup('label', labelContents, labelAttrs)]
           if (toggle) {
+            delete labelAttrs.for
             labelAttrs.className = 'kc-toggle'
             labelContents.unshift(input, this.markup('span'))
             output = this.markup('label', labelContents, labelAttrs)


### PR DESCRIPTION
If there is a duplicate ID for an input kc-toggle will not work for the subsequent input due to the for attribute sending the event to the first input.

Fixes #1536