### PR TITLE
syncFieldWithNewRow incorrectly replacing row values className attribute when element not current within row

### DIFF
--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -2139,13 +2139,27 @@ function FormBuilder(opts, element, $) {
     })
   }
 
+  /**
+   * Updates the field's className to include the current wrapping row, removing the previous row if defined
+   * @param fieldID
+   */
   function syncFieldWithNewRow(fieldID) {
     if (fieldID) {
       const inputClassElement = $(`#className-${fieldID.replace('-cont', '')}`)
-      if (inputClassElement.val()) {
-        const oldRow = h.getRowClass(inputClassElement.val())
+      const currentClassName = inputClassElement.val().trim()
+      if (currentClassName) {
+        let currentClasses = currentClassName.split(' ')
+        const oldRow = h.getRowClass(currentClassName)
         const wrapperRow = h.getRowClass(inputClassElement.closest(rowWrapperClassSelector).attr('class'))
-        inputClassElement.val(inputClassElement.val().replace(oldRow, wrapperRow))
+        if (oldRow !== wrapperRow) {
+          if (oldRow) {
+            currentClasses = currentClasses.filter(function(obj) {
+              return obj !== oldRow
+            })
+          }
+          currentClasses.push(wrapperRow)
+          inputClassElement.val(currentClasses.join(' '))
+        }
         checkRowCleanup()
       }
     }


### PR DESCRIPTION
Fixes #1575

When drag + drop a field from one row to a new row the function syncFieldWithNewRow() is called 3 times, once in the sortable update: callback which removes the existing row, and again in receive: callback. On the second call the oldRow value is an empty string, which resulted in the replace() call having an empty pattern and corrupting the classString.

Reimplemented syncFieldWithNewRow by operating on the classNames as an array, handling the case where we drop onto the same row or no row value exists.