### PR TITLE
Fix/1556 hide second sortable-options remove button for select fields

### DIFF
--- a/src/sass/_stage.scss
+++ b/src/sass/_stage.scss
@@ -451,7 +451,7 @@
     }
   }
 
-  .radio-group-field {
+  .radio-group-field, .select-field {
     .sortable-options li:nth-child(2) .remove {
       display: none;
     }


### PR DESCRIPTION
Select-field has the same option min as radio field, it should also have the same styles applied to hide the second field remove button.

Fixes #1556 