### PR TITLE
FormRender reduce DOM churn and ensure fields are appended in order

### DIFF
--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -96,7 +96,7 @@ class FormRender {
         if (!Array.isArray(fields)) {
           fields = [fields]
         }
-        const renderedFormWrap = utils.markup('div', fields, {
+        const renderedFormWrap = utils.markup('div', null, {
           className: 'rendered-form formbuilder-embedded-bootstrap',
         })
         this.appendChild(renderedFormWrap)


### PR DESCRIPTION
Fields were appended first into the rendered-form element and then re-appended to the bottom of the rendered-form in the loop below. A fields DOM position is therefore out of order on the second append until the time that all fields are processed. We fix this by removing the initial whole append and which also removes the need for the browser to relocate the element.