### PR TITLE
Fix formData collection when additional Option fields are configured.

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -138,7 +138,7 @@ export default class Helpers {
 
     $options.each(i => {
       const option = $options[i]
-      const stringAttrs = option.querySelectorAll('input[type=text], input[type=number], select')
+      const stringAttrs = option.querySelectorAll('input:not([type=checkbox]):not([type=radio]), select')
       const boolAttrs = option.querySelectorAll('input[type=checkbox], input[type=radio]')
       const attrs = {}
 

--- a/src/sass/_stage.scss
+++ b/src/sass/_stage.scss
@@ -453,7 +453,8 @@
 
   .radio-group-field, .select-field {
     .sortable-options li:nth-child(2) .remove {
-      display: none;
+      opacity: 0;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
When using onAddOption to add additional option fields (a colour field in this example) the collection of the field attributes would skip any inputs not of type text or number. Widen the selector to grab all non-boolean input types. A small CSS fix is also added for hiding the second remove button without affecting layout.

```javascript
onAddOption: (optionTemplate, optionInfo) => {
            const colours = [
                "#32e544", "#22e87e", "#30c6c9", "#d87c52", "#bdd602", "#1d0093", "#ce58ef", "#820a00", "#0b07ef", "#195d7f", "#d84eca", "#c3f497", "#e2c102", "#cc322c", "#a9f9ec", "#07b234", "#dd1641", "#93f2ed", "#74f765"
            ];

            optionTemplate.label = `Option ${optionInfo.index + 1}`;
            optionTemplate.value = `option-${optionInfo.index + 1}`;
            optionTemplate['data-colour'] = {tag: 'input','type': "color", "value": colours[(optionInfo.index + 1)% colours.length], };

            return optionTemplate;
        }
```

<img width="695" height="217" alt="image" src="https://github.com/user-attachments/assets/4e54fda1-bbe4-4866-b932-ccb9bfcb08f7" />

Before:
```javascript
"values":[
  {"label":"Option 1","value":"option-1","selected":true},
  {"label":"Option 2","value":"option-2","selected":false},
  {"label":"Option 3","value":"option-3","selected":false}
]}]
```

After:
```javascript
"values":[
  {"label":"Option 1","value":"option-1","data-colour":"#22e87e","selected":true},
  {"label":"Option 2","value":"option-2","data-colour":"#30c6c9","selected":false},
  {"label":"Option 3","value":"option-3","data-colour":"#d87c52","selected":false}
]}]
```
