### PR TITLE
fix: #1635 field label not preserved when changing subtype

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,9 +96,9 @@
     "lint": "eslint ./src || true",
     "lint:fix": "eslint ./src --fix",
     "semantic-release": "semantic-release",
-    "start:devServer": "webpack-dev-server --mode development --config tools/webpack.config",
-    "prestart": "run-p build:vendor copy:lang",
+    "start:devServer": "run-p build:vendor copy:lang && webpack-dev-server --mode development --config tools/webpack.config",
     "start": "npm run start:devServer",
+    "dev": "npm run start",
     "test": "jest --coverage",
     "prepare": "[ \"$NODE_ENV\" = production ] && exit 0; husky install",
     "pre-commit": "lint-staged"

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -536,6 +536,7 @@ function FormBuilder(opts, element, $) {
             const curAdvFields = evt.target.closest('.form-elements-inner')
             const newAdvFields = generateAdvFields({ ...values, subtype: value })
             curAdvFields.replaceWith(newAdvFields)
+            debugger
           }
         }
         return selectAttribute('subtype', { events, ...values }, subtypes[type], isHidden)
@@ -690,7 +691,7 @@ function FormBuilder(opts, element, $) {
         ['array', ({ options }) => !!options],
         ['boolean', ({ type }) => type === 'checkbox'], // automatic bool if checkbox
         ['options', ({ type }) => type === 'options'],
-        [typeof value, () => true], // string, number, 
+        [typeof value, () => true], // string, number,
       ].find(typeCondition => typeCondition[1](attrData))[0]
     )
   }
@@ -1830,6 +1831,10 @@ function FormBuilder(opts, element, $) {
     setElementContent(label, parsedHtml(value), config.opts.disableHTMLLabels)
   })
 
+  $stage.on('blur', '.fld-*', () => {
+    h.save.call(h)
+  })
+
   // remove error styling when users tries to correct mistake
   $stage.on('keyup', 'input.error', ({ target }) => $(target).removeClass('error'))
 
@@ -2289,8 +2294,8 @@ function FormBuilder(opts, element, $) {
   function buildGridModeHelp() {
     $(gridModeHelp).html(`
     <div style='padding:5px'>
-      <h3 class="text text-center">Grid Mode</h3>    
-      
+      <h3 class="text text-center">Grid Mode</h3>
+
       <table style='border-spacing:7px;border-collapse: separate'>
         <thead>
           <tr>
@@ -2302,13 +2307,13 @@ function FormBuilder(opts, element, $) {
           <tr>
             <td><kbd>MOUSEWHEEL</kbd></td>
             <td>Adjust the field column size</td>
-          </tr>    
+          </tr>
           <tr>
-            <td><kbd>W or &#x2191;</kbd></td> 
+            <td><kbd>W or &#x2191;</kbd></td>
             <td>Move entire row up</td>
           </tr>
           <tr>
-              <td><kbd>S or &#x2193;</kbd></td> 
+              <td><kbd>S or &#x2193;</kbd></td>
               <td>Move entire row down</td>
           </tr>
           <tr>
@@ -2316,25 +2321,25 @@ function FormBuilder(opts, element, $) {
               <td>Move field left within the row</td>
           </tr>
           <tr>
-              <td><kbd>D or &#x2192;</kbd></td> 
+              <td><kbd>D or &#x2192;</kbd></td>
               <td>Move field right within the row</td>
           </tr>
           <tr>
-            <td><kbd>R</kbd></td> 
+            <td><kbd>R</kbd></td>
             <td>Resize all fields within the row to be maximally equal</td>
           </tr>
           <tr>
-        </tbody> 
+        </tbody>
       </table>
 
-      <h5 class="text text-center" style='padding-top:10px'>Current Row Fields</h5>    
-      
+      <h5 class="text text-center" style='padding-top:10px'>Current Row Fields</h5>
+
       <table class='gridHelpCurrentRow'>
         <colgroup>
           <col width="100%" />
           <col width="0%" />
         </colgroup>
-        
+
         <thead>
           <tr>
             <th>Field</th>
@@ -2343,9 +2348,9 @@ function FormBuilder(opts, element, $) {
         </thead>
 
         <tbody>
-        </tbody> 
+        </tbody>
       </table>
-      
+
     </div>
     `)
 

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -533,8 +533,9 @@ function FormBuilder(opts, element, $) {
         const events = {
           change: evt => {
             const { value } = evt.target
+            const field = closest(evt.target, '.form-field')
             const curAdvFields = evt.target.closest('.form-elements-inner')
-            const newAdvFields = generateAdvFields({ ...values, subtype: value })
+            const newAdvFields = generateAdvFields({ ...values, ...h.getAttrVals(field), subtype: value })
             curAdvFields.replaceWith(newAdvFields)
           }
         }
@@ -1828,10 +1829,6 @@ function FormBuilder(opts, element, $) {
     const value = target.value || target.innerHTML
     const label = closest(target, '.form-field').querySelector('.field-label')
     setElementContent(label, parsedHtml(value), config.opts.disableHTMLLabels)
-  })
-
-  $stage.on('blur', '.fld-*', () => {
-    h.save.call(h)
   })
 
   // remove error styling when users tries to correct mistake

--- a/src/js/form-builder.js
+++ b/src/js/form-builder.js
@@ -536,7 +536,6 @@ function FormBuilder(opts, element, $) {
             const curAdvFields = evt.target.closest('.form-elements-inner')
             const newAdvFields = generateAdvFields({ ...values, subtype: value })
             curAdvFields.replaceWith(newAdvFields)
-            debugger
           }
         }
         return selectAttribute('subtype', { events, ...values }, subtypes[type], isHidden)

--- a/tests/form-builder.test.js
+++ b/tests/form-builder.test.js
@@ -183,7 +183,7 @@ describe('FormBuilder stage names translated', () => {
 })
 
 describe('FormBuilder attribute setup', () => {
-  test('changing subtype preserves unsaved label edits after label blur', async() => {
+  test('changing subtype preserves unsaved label edits', async() => {
     const fbWrap = $('<div>')
     const fb = await fbWrap.formBuilder({}).promise
 
@@ -195,7 +195,7 @@ describe('FormBuilder attribute setup', () => {
 
     const field = fbWrap.find('.form-field[type="text"]')
     const labelInput = field.find('.fld-label')
-    labelInput.text('Current Label').trigger('input').trigger('blur')
+    labelInput.text('Current Label').trigger('input')
 
     const subtypeInput = field.find('.fld-subtype')
     subtypeInput.val('email').trigger('change')

--- a/tests/form-builder.test.js
+++ b/tests/form-builder.test.js
@@ -183,6 +183,31 @@ describe('FormBuilder stage names translated', () => {
 })
 
 describe('FormBuilder attribute setup', () => {
+  test('changing subtype preserves unsaved label edits after label blur', async() => {
+    const fbWrap = $('<div>')
+    const fb = await fbWrap.formBuilder({}).promise
+
+    fb.actions.addField({
+      type: 'text',
+      label: 'Saved Label',
+    })
+    fb.actions.toggleFieldEdit(0)
+
+    const field = fbWrap.find('.form-field[type="text"]')
+    const labelInput = field.find('.fld-label')
+    labelInput.text('Current Label').trigger('input').trigger('blur')
+
+    const subtypeInput = field.find('.fld-subtype')
+    subtypeInput.val('email').trigger('change')
+
+    expect(field.find('.fld-label').text()).toBe('Current Label')
+    expect(field.find('.field-label').text()).toBe('Current Label')
+    expect(fb.actions.getData()[0]).toEqual(expect.objectContaining({
+      label: 'Current Label',
+      subtype: 'email',
+    }))
+  })
+
   test('number control number attributes do not inherit field value when not set', async() => {
     const config = {}
     const fbWrap = $('<div>')


### PR DESCRIPTION
- **fix: vendor assets missing on first npm start**
- **fix: field label reset when changing the subtype without saving**
- **chore: add test to verify fix**


resolves #1635 