### PR TITLE
fix: 1634 - toggle not working on firefox

### DIFF
--- a/src/js/control/select.js
+++ b/src/js/control/select.js
@@ -36,7 +36,7 @@ export default class controlSelect extends control {
     if ((type === 'checkbox-group' || type === 'radio-group') && data.required) {
       const self = this
       const defaultOnRender = this.onRender.bind(this)
-      this.onRender = function() {
+      this.onRender = function () {
         defaultOnRender()
         self.groupRequired()
       }
@@ -141,10 +141,14 @@ export default class controlSelect extends control {
     }
 
     // build & return the DOM elements
-    if (type == 'select') {
+    if (type === 'select') {
       this.dom = this.markup(optionType, options, trimObj(data, true))
     } else {
-      this.dom = this.markup('div', options, { className: type })
+      let className = type
+      if (inline) {
+        className += ` ${className}--inline`
+      }
+      this.dom = this.markup('div', options, { className })
     }
     return this.dom
   }
@@ -159,14 +163,14 @@ export default class controlSelect extends control {
     const otherValue = this.element.querySelector('.other-val')
     const setValidity = (checkbox, isValid) => {
       const minReq = control.mi18n('minSelectionRequired', 1)
-      if (!isValid) {
-        checkbox.setCustomValidity(minReq)
-      } else {
+      if (isValid) {
         checkbox.setCustomValidity('')
+      } else {
+        checkbox.setCustomValidity(minReq)
       }
     }
     const toggleRequired = (checkboxes, otherCheckbox, otherValue, isValid) => {
-        [].forEach.call(checkboxes, cb => {
+      Array.prototype.forEach.call(checkboxes, cb => {
         if (isValid) {
           cb.removeAttribute('required')
         } else {

--- a/src/js/sanitizer.js
+++ b/src/js/sanitizer.js
@@ -10,25 +10,32 @@ const sanitizerConfig = {
   },
   backendOrder: ['dompurify', 'sanitizer', 'fallback'],
   backends: {
-    sanitizer: typeof window['Sanitizer'] === 'function' ? new window.Sanitizer({
-      // Explicitly allow form elements and common HTML elements to prevent
-      // Firefox 148+ Sanitizer API from stripping <input>, <select>, etc.
-      // See: https://github.com/kevinchappell/formBuilder/issues/1634
-      elements: [
-        'div', 'p', 'br', 'span', 'strong', 'em', 'b', 'i', 'u',
-        'ul', 'ol', 'li', 'a', 'img', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
-        'form', 'label', 'input', 'select', 'option', 'textarea', 'button',
-        'fieldset', 'legend', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-      ],
-      attributes: [
-        'class', 'id', 'title', 'contenteditable', 'href', 'target', 'rel',
-        'src', 'alt', 'width', 'height', 'type', 'name', 'value', 'checked',
-        'disabled', 'placeholder', 'required', 'for', 'selected', 'rows',
-        'cols', 'multiple', 'method', 'action', 'tabindex', 'readonly',
-        'minlength', 'maxlength', 'pattern', 'autocomplete', 'autofocus',
-      ],
-      dataAttributes: true,
-    }) : false,
+    sanitizer: (() => {
+      if (typeof window['Sanitizer'] !== 'function') return false
+      try {
+        // Explicitly allow form elements and common HTML elements to prevent
+        // Firefox 148+ Sanitizer API from stripping <input>, <select>, etc.
+        // See: https://github.com/kevinchappell/formBuilder/issues/1634
+        return new window.Sanitizer({
+          elements: [
+            'div', 'p', 'br', 'span', 'strong', 'em', 'b', 'i', 'u',
+            'ul', 'ol', 'li', 'a', 'img', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
+            'form', 'label', 'input', 'select', 'option', 'textarea', 'button',
+            'fieldset', 'legend', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+          ],
+          attributes: [
+            'class', 'id', 'title', 'contenteditable', 'href', 'target', 'rel',
+            'src', 'alt', 'width', 'height', 'type', 'name', 'value', 'checked',
+            'disabled', 'placeholder', 'required', 'for', 'selected', 'rows',
+            'cols', 'multiple', 'method', 'action', 'tabindex', 'readonly',
+            'minlength', 'maxlength', 'pattern', 'autocomplete', 'autofocus',
+          ],
+          dataAttributes: true,
+        })
+      } catch (e) {
+        return false
+      }
+    })(),
     dompurify: window.DOMPurify ? (purify => {
       purify.setConfig({
         //USE_PROFILES: { html: true }, //Only process HTML (exclude SVG and MATHML)

--- a/src/js/sanitizer.js
+++ b/src/js/sanitizer.js
@@ -10,7 +10,25 @@ const sanitizerConfig = {
   },
   backendOrder: ['dompurify', 'sanitizer', 'fallback'],
   backends: {
-    sanitizer: typeof window['Sanitizer'] === 'function' ? new window.Sanitizer() : false,
+    sanitizer: typeof window['Sanitizer'] === 'function' ? new window.Sanitizer({
+      // Explicitly allow form elements and common HTML elements to prevent
+      // Firefox 148+ Sanitizer API from stripping <input>, <select>, etc.
+      // See: https://github.com/kevinchappell/formBuilder/issues/1634
+      elements: [
+        'div', 'p', 'br', 'span', 'strong', 'em', 'b', 'i', 'u',
+        'ul', 'ol', 'li', 'a', 'img', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
+        'form', 'label', 'input', 'select', 'option', 'textarea', 'button',
+        'fieldset', 'legend', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+      ],
+      attributes: [
+        'class', 'id', 'title', 'contenteditable', 'href', 'target', 'rel',
+        'src', 'alt', 'width', 'height', 'type', 'name', 'value', 'checked',
+        'disabled', 'placeholder', 'required', 'for', 'selected', 'rows',
+        'cols', 'multiple', 'method', 'action', 'tabindex', 'readonly',
+        'minlength', 'maxlength', 'pattern', 'autocomplete', 'autofocus',
+      ],
+      dataAttributes: true,
+    }) : false,
     dompurify: window.DOMPurify ? (purify => {
       purify.setConfig({
         //USE_PROFILES: { html: true }, //Only process HTML (exclude SVG and MATHML)

--- a/src/sass/_kc-toggle.scss
+++ b/src/sass/_kc-toggle.scss
@@ -1,5 +1,6 @@
 .kc-toggle {
-  padding-left: 0 !important;
+  display:flex;
+  align-items: center;
 
   span {
     position: relative;
@@ -11,7 +12,6 @@
     border: 1px solid lighten($grey, 40%);
     padding: 2px;
     overflow: hidden;
-    float: left;
     margin-right: 5px;
     will-change: transform;
 
@@ -26,7 +26,7 @@
       position: relative;
       content: '';
       width: 50%;
-      height: 100%;
+      height: calc(100% - 2px);
       left: 0;
       border-radius: 3px;
       background: linear-gradient(to bottom, lighten($grey-light-30, 30%) 0%, $grey-light 100%);
@@ -57,7 +57,7 @@
 
     &:checked + span {
       &::after {
-        transform: translateX(100%);
+        transform: translateX(calc(100% - 4px));
       }
 
       &::before {

--- a/src/sass/base/_fields.scss
+++ b/src/sass/base/_fields.scss
@@ -3,8 +3,8 @@
   color: $error;
 }
 
-.checkbox-group{
-  display:flex;
+.checkbox-group {
+  display: flex;
   flex-direction: column;
   gap: 8px;
 

--- a/src/sass/base/_fields.scss
+++ b/src/sass/base/_fields.scss
@@ -3,18 +3,21 @@
   color: $error;
 }
 
-.checkbox-group {
+.checkbox-group,
+.radio-group {
   display: flex;
   flex-direction: column;
   gap: 8px;
 
-  &.checkbox-group--inline {
+  &.checkbox-group--inline,
+  &.radio-group--inline {
     flex-direction: row;
   }
 }
 
 .formbuilder-checkbox-group,
 .formbuilder-radio-group {
+
   input[type='checkbox'],
   input[type='radio'] {
     margin: 0 4px 0 0;

--- a/src/sass/base/_fields.scss
+++ b/src/sass/base/_fields.scss
@@ -3,30 +3,22 @@
   color: $error;
 }
 
+.checkbox-group{
+  display:flex;
+  flex-direction: column;
+  gap: 8px;
+
+  &.checkbox-group--inline {
+    flex-direction: row;
+  }
+}
+
 .formbuilder-checkbox-group,
 .formbuilder-radio-group {
   input[type='checkbox'],
   input[type='radio'] {
     margin: 0 4px 0 0;
   }
-}
-
-.formbuilder-checkbox-inline,
-.formbuilder-radio-inline {
-  margin-right: 8px;
-  display: inline-block;
-  vertical-align: middle;
-  padding-left: 0;
-  label {
-    input[type='text'] {
-      margin-top: 0;
-    }
-  }
-}
-
-.formbuilder-checkbox-inline:first-child,
-.formbuilder-radio-inline:first-child {
-  padding-left: 0;
 }
 
 .formbuilder-autocomplete-list {

--- a/tests/sanitizer.test.js
+++ b/tests/sanitizer.test.js
@@ -95,14 +95,10 @@ describe('Sanitizer API backend', () => {
   let setElementContentSanitizer
   let setSanitizerConfigSanitizer
   let mockSanitizerConstructor
-  let capturedSanitizerConfig
   let mockSetHTML
 
   beforeAll(() => {
-    // Capture the config passed to the Sanitizer constructor
-    capturedSanitizerConfig = null
-    mockSanitizerConstructor = jest.fn(function (config) {
-      capturedSanitizerConfig = config
+    mockSanitizerConstructor = jest.fn(function () {
       return this
     })
     window.Sanitizer = mockSanitizerConstructor
@@ -130,21 +126,20 @@ describe('Sanitizer API backend', () => {
   })
 
   test('instantiates Sanitizer with a form element allowlist', () => {
-    expect(mockSanitizerConstructor).toHaveBeenCalledTimes(1)
-    const elements = capturedSanitizerConfig.elements
-    expect(elements).toContain('input')
-    expect(elements).toContain('select')
-    expect(elements).toContain('textarea')
-    expect(elements).toContain('label')
-    expect(elements).toContain('button')
+    const config = mockSanitizerConstructor.mock.calls[0][0]
+    expect(config.elements).toContain('input')
+    expect(config.elements).toContain('select')
+    expect(config.elements).toContain('textarea')
+    expect(config.elements).toContain('label')
+    expect(config.elements).toContain('button')
   })
 
   test('instantiates Sanitizer with a form attribute allowlist', () => {
-    const attributes = capturedSanitizerConfig.attributes
-    expect(attributes).toContain('type')
-    expect(attributes).toContain('name')
-    expect(attributes).toContain('value')
-    expect(attributes).toContain('checked')
+    const config = mockSanitizerConstructor.mock.calls[0][0]
+    expect(config.attributes).toContain('type')
+    expect(config.attributes).toContain('name')
+    expect(config.attributes).toContain('value')
+    expect(config.attributes).toContain('checked')
   })
 
   test('uses setHTML when the Sanitizer backend is active', () => {
@@ -164,35 +159,36 @@ describe('Sanitizer API backend', () => {
     expect(el.innerHTML).toContain('<label')
   })
 
-  test('falls back to false when Sanitizer constructor throws', () => {
-    // Temporarily replace Sanitizer with one that throws
-    const throwingSanitizer = jest.fn(() => {
-      throw new Error('Unsupported config')
-    })
-    window.Sanitizer = throwingSanitizer
-    jest.resetModules()
-    const mod = require('./../src/js/sanitizer.js')
-    const setSanitizerConfigLocal = mod.setSanitizerConfig
-    const setElementContentLocal = mod.setElementContent
-    setSanitizerConfigLocal({ backendOrder: ['sanitizer'] })
+  describe('when Sanitizer constructor throws', () => {
+    let setElementContentLocal
 
-    // With sanitizer backend returning false, setHTML should NOT be called
-    const freshSetHTML = jest.fn(function (content) {
-      this.innerHTML = content
+    beforeAll(() => {
+      window.Sanitizer = jest.fn(function () {
+        throw new Error('Unsupported config')
+      })
+      jest.resetModules()
+      const mod = require('./../src/js/sanitizer.js')
+      setElementContentLocal = mod.setElementContent
+      mod.setSanitizerConfig({ backendOrder: ['sanitizer'] })
     })
-    Element.prototype.setHTML = freshSetHTML
-    const el = document.createElement('div')
-    setElementContentLocal(el, '<p>test</p>', false)
-    expect(freshSetHTML).not.toHaveBeenCalled()
 
-    // Restore for subsequent tests and re-require so module state is consistent
-    window.Sanitizer = mockSanitizerConstructor
-    Element.prototype.setHTML = mockSetHTML
-    jest.resetModules()
-    const restoredMod = require('./../src/js/sanitizer.js')
-    setElementContentSanitizer = restoredMod.setElementContent
-    setSanitizerConfigSanitizer = restoredMod.setSanitizerConfig
-    setSanitizerConfigSanitizer({ backendOrder: ['sanitizer'] })
+    afterAll(() => {
+      // Restore the outer mock so the outer afterAll clean-up is consistent
+      window.Sanitizer = mockSanitizerConstructor
+      jest.resetModules()
+    })
+
+    test('falls back to false and does not call setHTML', () => {
+      const freshSetHTML = jest.fn(function (content) {
+        this.innerHTML = content
+      })
+      Element.prototype.setHTML = freshSetHTML
+      const el = document.createElement('div')
+      setElementContentLocal(el, '<p>test</p>', false)
+      expect(freshSetHTML).not.toHaveBeenCalled()
+      // Restore prototype for outer describe clean-up
+      Element.prototype.setHTML = mockSetHTML
+    })
   })
 })
 

--- a/tests/sanitizer.test.js
+++ b/tests/sanitizer.test.js
@@ -103,6 +103,7 @@ describe('Sanitizer API backend', () => {
     capturedSanitizerConfig = null
     mockSanitizerConstructor = jest.fn(function (config) {
       capturedSanitizerConfig = config
+      return this
     })
     window.Sanitizer = mockSanitizerConstructor
 
@@ -184,9 +185,14 @@ describe('Sanitizer API backend', () => {
     setElementContentLocal(el, '<p>test</p>', false)
     expect(freshSetHTML).not.toHaveBeenCalled()
 
-    // Restore for subsequent tests
+    // Restore for subsequent tests and re-require so module state is consistent
     window.Sanitizer = mockSanitizerConstructor
     Element.prototype.setHTML = mockSetHTML
+    jest.resetModules()
+    const restoredMod = require('./../src/js/sanitizer.js')
+    setElementContentSanitizer = restoredMod.setElementContent
+    setSanitizerConfigSanitizer = restoredMod.setSanitizerConfig
+    setSanitizerConfigSanitizer({ backendOrder: ['sanitizer'] })
   })
 })
 

--- a/tests/sanitizer.test.js
+++ b/tests/sanitizer.test.js
@@ -91,6 +91,105 @@ backends.forEach(backend => {
   })
 })
 
+describe('Sanitizer API backend', () => {
+  let setElementContentSanitizer
+  let setSanitizerConfigSanitizer
+  let mockSanitizerConstructor
+  let capturedSanitizerConfig
+  let mockSetHTML
+
+  beforeAll(() => {
+    // Capture the config passed to the Sanitizer constructor
+    capturedSanitizerConfig = null
+    mockSanitizerConstructor = jest.fn(function (config) {
+      capturedSanitizerConfig = config
+    })
+    window.Sanitizer = mockSanitizerConstructor
+
+    // Provide a setHTML implementation on Element.prototype so the sanitizer
+    // backend callback can call element.setHTML(content, { sanitizer })
+    mockSetHTML = jest.fn(function (content) {
+      this.innerHTML = content
+    })
+    Element.prototype.setHTML = mockSetHTML
+
+    // Re-require the module after mocking so the IIFE picks up window.Sanitizer
+    jest.resetModules()
+    const mod = require('./../src/js/sanitizer.js')
+    setElementContentSanitizer = mod.setElementContent
+    setSanitizerConfigSanitizer = mod.setSanitizerConfig
+
+    setSanitizerConfigSanitizer({ backendOrder: ['sanitizer'] })
+  })
+
+  afterAll(() => {
+    delete window.Sanitizer
+    delete Element.prototype.setHTML
+    jest.resetModules()
+  })
+
+  test('instantiates Sanitizer with a form element allowlist', () => {
+    expect(mockSanitizerConstructor).toHaveBeenCalledTimes(1)
+    const elements = capturedSanitizerConfig.elements
+    expect(elements).toContain('input')
+    expect(elements).toContain('select')
+    expect(elements).toContain('textarea')
+    expect(elements).toContain('label')
+    expect(elements).toContain('button')
+  })
+
+  test('instantiates Sanitizer with a form attribute allowlist', () => {
+    const attributes = capturedSanitizerConfig.attributes
+    expect(attributes).toContain('type')
+    expect(attributes).toContain('name')
+    expect(attributes).toContain('value')
+    expect(attributes).toContain('checked')
+  })
+
+  test('uses setHTML when the Sanitizer backend is active', () => {
+    const el = document.createElement('div')
+    setElementContentSanitizer(el, '<input type="checkbox">', false)
+    expect(mockSetHTML).toHaveBeenCalled()
+  })
+
+  test('preserves form elements via the Sanitizer backend', () => {
+    mockSetHTML.mockImplementation(function (content) {
+      // Simulate a Sanitizer that keeps all allowed elements
+      this.innerHTML = content
+    })
+    const el = document.createElement('div')
+    setElementContentSanitizer(el, '<label><input type="checkbox" checked> Accept</label>', false)
+    expect(el.innerHTML).toContain('<input')
+    expect(el.innerHTML).toContain('<label')
+  })
+
+  test('falls back to false when Sanitizer constructor throws', () => {
+    // Temporarily replace Sanitizer with one that throws
+    const throwingSanitizer = jest.fn(() => {
+      throw new Error('Unsupported config')
+    })
+    window.Sanitizer = throwingSanitizer
+    jest.resetModules()
+    const mod = require('./../src/js/sanitizer.js')
+    const setSanitizerConfigLocal = mod.setSanitizerConfig
+    const setElementContentLocal = mod.setElementContent
+    setSanitizerConfigLocal({ backendOrder: ['sanitizer'] })
+
+    // With sanitizer backend returning false, setHTML should NOT be called
+    const freshSetHTML = jest.fn(function (content) {
+      this.innerHTML = content
+    })
+    Element.prototype.setHTML = freshSetHTML
+    const el = document.createElement('div')
+    setElementContentLocal(el, '<p>test</p>', false)
+    expect(freshSetHTML).not.toHaveBeenCalled()
+
+    // Restore for subsequent tests
+    window.Sanitizer = mockSanitizerConstructor
+    Element.prototype.setHTML = mockSetHTML
+  })
+})
+
 describe('Potentially dangerous attributes', () => {
   test('onerror attribute is dangerous', () => {
     expect(isPotentiallyDangerousAttribute('onerror', 'alert("")')).toBe(true)


### PR DESCRIPTION
- **fix: configure Sanitizer API to preserve form elements in Firefox 148+**
- **style: tighten up checkbox toggle**

resolves #1634 

[Screencast from 2026-05-02 14-19-12.webm](https://github.com/user-attachments/assets/4690d271-d54b-436d-b995-cf683b3c81ff)

